### PR TITLE
Added feature #120 - Share Encryption Keys

### DIFF
--- a/Settings/Base.lproj/Settings.storyboard
+++ b/Settings/Base.lproj/Settings.storyboard
@@ -446,7 +446,13 @@
                             <outlet property="delegate" destination="pXM-Xm-FZf" id="NdJ-hH-77a"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Key Info" id="qhd-NB-qh5"/>
+                    <navigationItem key="navigationItem" title="Key Info" id="qhd-NB-qh5">
+                        <barButtonItem key="rightBarButtonItem" systemItem="action" id="OeI-ix-a5m">
+                            <connections>
+                                <action selector="sharePublicKey:" destination="pXM-Xm-FZf" id="ZaW-8r-kcV"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="name" destination="r3k-R8-kUF" id="1wI-wk-6Hj"/>
                         <segue destination="dez-Wo-FoG" kind="unwind" identifier="unwindFromDetails" unwindAction="unwindFromDetails:" id="WUW-4L-MSF"/>

--- a/Settings/Model/BKPubKey.h
+++ b/Settings/Model/BKPubKey.h
@@ -30,6 +30,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 
 @interface SshRsa : NSObject
@@ -42,7 +43,7 @@
 
 @end
 
-@interface BKPubKey : NSObject <NSCoding>
+@interface BKPubKey : NSObject <NSCoding, UIActivityItemSource>
 
 @property NSString *ID;
 @property (readonly) NSString *privateKey;

--- a/Settings/ViewControllers/BKPubKey/BKPubKeyDetailsViewController.m
+++ b/Settings/ViewControllers/BKPubKey/BKPubKeyDetailsViewController.m
@@ -93,6 +93,20 @@
   [pb setString:_pubkey.privateKey];
 }
 
+- (IBAction)sharePublicKey:(id)sender
+{
+  NSArray *sharingItems = @[_pubkey];
+
+  UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:sharingItems applicationActivities:nil];
+  activityController.excludedActivityTypes = @[UIActivityTypePostToTwitter, UIActivityTypePostToFacebook,
+                                               UIActivityTypePostToWeibo, UIActivityTypeCopyToPasteboard,
+                                               UIActivityTypeAssignToContact, UIActivityTypeSaveToCameraRoll,
+                                               UIActivityTypeAddToReadingList, UIActivityTypePostToFlickr,
+                                               UIActivityTypePostToVimeo, UIActivityTypePostToTencentWeibo];
+  activityController.popoverPresentationController.barButtonItem = sender;
+  [self presentViewController:activityController animated:YES completion:nil];
+}
+
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
   if ([segue.identifier isEqualToString:@"unwindFromDetails"]) {


### PR DESCRIPTION
Hi Everyone,

I've implemented a share sheet for the public keys. I've made a couple of assumptions that I'm happy to change if people don't think it's a good idea.

I've added the UIActivityItemSource interface to the BKPubKey class. This gives us the ability to define what's returned when we try to share this type of object. Not sure if this is the best way or should be elsewhere - happy to take other people's advice on this.

I've also decided when a key is shared via AirDrop or email a temporary file is created named "{_ID}.pub". For other share types it just returns the public key as a string. Again, happy to change this if people think something better would work.

Cheers,
Chris