### PR TITLE
GitHub HTML URLs are replaced with raw urls

### DIFF
--- a/Settings/ViewControllers/Appearance/BKFontCreateViewController.m
+++ b/Settings/ViewControllers/Appearance/BKFontCreateViewController.m
@@ -99,11 +99,16 @@
 
 - (IBAction)importButtonClicked:(id)sender
 {
-  if (_urlTextField.text.length > 4 && [[_urlTextField.text substringFromIndex:[_urlTextField.text length] - 4] isEqualToString:@".css"]) {
+  NSString *fontUrl = _urlTextField.text;
+  if (fontUrl.length > 4 && [[fontUrl substringFromIndex:[fontUrl length] - 4] isEqualToString:@".css"]) {
+    if ([fontUrl rangeOfString:@"github.com"].location != NSNotFound && [fontUrl rangeOfString:@"/raw/"].location == NSNotFound) {
+      // Replace HTML versions of fonts with the raw version
+      fontUrl = [fontUrl stringByReplacingOccurrencesOfString:@"/blob/" withString:@"/raw/"];
+    }
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
     [self configureImportButtonForCancel];
     self.urlTextField.enabled = NO;
-    [BKSettingsFileDownloader downloadFileAtUrl:_urlTextField.text
+    [BKSettingsFileDownloader downloadFileAtUrl:fontUrl
                           withCompletionHandler:^(NSData *fileData, NSError *error) {
                             if (error == nil) {
                               [self performSelectorOnMainThread:@selector(downloadCompletedWithFilePath:) withObject:fileData waitUntilDone:NO];

--- a/Settings/ViewControllers/Appearance/BKThemeCreateViewController.m
+++ b/Settings/ViewControllers/Appearance/BKThemeCreateViewController.m
@@ -99,11 +99,16 @@
 
 - (IBAction)importButtonClicked:(id)sender
 {
-  if (_urlTextField.text.length > 4 && [[_urlTextField.text substringFromIndex:[_urlTextField.text length] - 3] isEqualToString:@".js"]) {
+  NSString *themeUrl = _urlTextField.text;
+  if (themeUrl.length > 4 && [[themeUrl substringFromIndex:[themeUrl length] - 3] isEqualToString:@".js"]) {
+    if ([themeUrl rangeOfString:@"github.com"].location != NSNotFound && [themeUrl rangeOfString:@"/raw/"].location == NSNotFound) {
+      // Replace HTML versions of themes with the raw version
+      themeUrl = [themeUrl stringByReplacingOccurrencesOfString:@"/blob/" withString:@"/raw/"];
+    }
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
     self.urlTextField.enabled = NO;
     [self configureImportButtonForCancel];
-    [BKSettingsFileDownloader downloadFileAtUrl:_urlTextField.text
+    [BKSettingsFileDownloader downloadFileAtUrl:themeUrl
                           withCompletionHandler:^(NSData *fileData, NSError *error) {
                             if (error == nil) {
                               [self performSelectorOnMainThread:@selector(downloadCompletedWithFilePath:) withObject:fileData waitUntilDone:NO];


### PR DESCRIPTION
Hi Carlos,

Hopefully a fix for #199. GitHub URLs for themes and fonts should now be converted to their "raw" URLs.

Potentially we could also check the content type returned by the HTTP request to make sure the files are CSS or Javascript as we're expecting.

Let me know if this isn't what you had in mind.

Cheers,
Eric