### PR TITLE
Disable autocapitalization

### DIFF
--- a/Blink/TermView.m
+++ b/Blink/TermView.m
@@ -414,6 +414,10 @@ NSString *const TermViewAutoRepeateSeq = @"autoRepeatSeq:";
 {
   return UITextAutocorrectionTypeNo;
 }
+- (UITextAutocapitalizationType)autocapitalizationType
+{
+  return UITextAutocapitalizationTypeNone;
+}
 
 - (UIView *)inputAccessoryView
 {


### PR DESCRIPTION
Autocapitalization is annoying in a terminal app. At least in ios 11.1 with a custom keyboard, autocapitalization is enabled on the keyboard, this disables it