### PR TITLE
Add padding to smart keys for landscape iPhone X

### DIFF
--- a/Blink/SmartKeys/SmartKeys.xib
+++ b/Blink/SmartKeys/SmartKeys.xib
@@ -214,10 +214,9 @@
                     </constraints>
                 </stackView>
             </subviews>
+            <color key="backgroundColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
             <constraints>
                 <constraint firstItem="o5R-mY-Oea" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" id="NiB-SB-3i0"/>
-                <constraint firstItem="6Kk-Wl-VMp" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="gqw-Dy-Ipc" userLabel="leading = Stack.leading"/>
-                <constraint firstItem="6Kk-Wl-VMp" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="uNz-4C-Iq6"/>
                 <constraint firstItem="6Kk-Wl-VMp" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="voi-FJ-sD9" userLabel="top=Stack.top"/>
                 <constraint firstItem="6Kk-Wl-VMp" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="zxZ-0Y-hcL"/>
             </constraints>

--- a/Blink/SmartKeys/SmartKeysView.m
+++ b/Blink/SmartKeys/SmartKeysView.m
@@ -84,6 +84,15 @@ NSString *const KbdTabKey = @"⇥";
 //  _nonModifierScrollView.translatesAutoresizingMaskIntoConstraints = NO;
   _nonModifierScrollView.backgroundColor = [UIColor grayColor];
   self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+
+  if (@available(iOS 11.0, *)) {
+    [self.safeAreaLayoutGuide.leadingAnchor constraintEqualToAnchor:_stack.leadingAnchor].active = YES;
+    [self.safeAreaLayoutGuide.trailingAnchor constraintEqualToAnchor:_stack.trailingAnchor].active = YES;
+  } else {
+    [self.leadingAnchor constraintEqualToAnchor:_stack.leadingAnchor].active = YES;
+    [self.trailingAnchor constraintEqualToAnchor:_stack.trailingAnchor].active = YES;
+  }
+  
   [self setupModifierButtons];
 }
 


### PR DESCRIPTION
I've started using Blink recently and have found myself super impressed with it. However, on iPhone X, the 'smart keys' above the keyboard get occluded by the iPhone X sensor housing. This patch removes the hardcoded leading / trailing constraints specified in `SmartKeys.xib` and instead add them in `awakeFromNib`, using safe area layout on iOS 11+, and regular leading / trailing anchors on iOS <11.

## Before

Note how the smart keys are occluded behind the iPhone X sensor housing

<img width="920" alt="screen shot 2018-03-22 at 6 06 49 pm" src="https://user-images.githubusercontent.com/320910/37756011-e7b4d39a-2dfb-11e8-87f4-3bf4258ee10a.png">

## After

We now respect the safe area insets

<img width="920" alt="screen shot 2018-03-22 at 6 07 15 pm" src="https://user-images.githubusercontent.com/320910/37756021-f0205176-2dfb-11e8-85e8-d4babebd8ed3.png">
