### PR TITLE
Fix for building on case-sensetive filesystems

### DIFF
--- a/Settings/Security/BKTouchIDAuthManager.m
+++ b/Settings/Security/BKTouchIDAuthManager.m
@@ -31,7 +31,7 @@
 
 #import "BKTouchIDAuthManager.h"
 #import "BKUserConfigurationManager.h"
-#import "Blink-swift.h"
+#import "Blink-Swift.h"
 
 const NSNotificationName BKUserAuthenticated = @"BKUserAuthenticated";
 

--- a/Settings/ViewControllers/UserConfiguration/BKSecurityConfigurationViewController.m
+++ b/Settings/ViewControllers/UserConfiguration/BKSecurityConfigurationViewController.m
@@ -32,7 +32,7 @@
 #import "BKSecurityConfigurationViewController.h"
 #import "BKTouchIDAuthManager.h"
 #import "BKUserConfigurationManager.h"
-#import "Blink-swift.h"
+#import "Blink-Swift.h"
 
 @interface BKSecurityConfigurationViewController () <UINavigationControllerDelegate>
 

--- a/Settings/ViewControllers/UserConfiguration/BKiCloudConfigurationViewController.m
+++ b/Settings/ViewControllers/UserConfiguration/BKiCloudConfigurationViewController.m
@@ -34,7 +34,7 @@
 
 #import "BKiCloudConfigurationViewController.h"
 #import "BKUserConfigurationManager.h"
-#import "Blink-swift.h"
+#import "Blink-Swift.h"
 
 @interface BKiCloudConfigurationViewController ()
 


### PR DESCRIPTION
Fixes "Blink-swift.h file not found" error when building on systems with case-sensitive filesystem.