### PR TITLE
Quickfix: Add alternative key commands for `prevShell:` and `nextShelll:` [#419] [#496]

### DIFF
--- a/Blink/SpaceController.m
+++ b/Blink/SpaceController.m
@@ -713,6 +713,21 @@
     [_kbdCommandsWithoutDiscoverability addObject:commandWithoutDiscoverability];
   }
   
+  // Alternative key commands for keyboard layouts having problems to access
+  // some of the default ones (e.g. the German keyboard layout)
+  UIKeyCommand * altPrevShell = [UIKeyCommand keyCommandWithInput: UIKeyInputLeftArrow
+                                                    modifierFlags: [BKUserConfigurationManager shortCutModifierFlagsForNextPrevShell]
+                                                           action: @selector(prevShell:)];
+  
+  UIKeyCommand * altNextShell = [UIKeyCommand keyCommandWithInput: UIKeyInputRightArrow
+                                                    modifierFlags: [BKUserConfigurationManager shortCutModifierFlagsForNextPrevShell]
+                                                           action: @selector(nextShell:)];
+  
+  [_kbdCommandsWithoutDiscoverability addObjectsFromArray:@[
+                                                            altPrevShell,
+                                                            altNextShell
+                                                            ]];
+  
 }
 
 - (void)_increaseFontSize:(UIKeyCommand *)cmd


### PR DESCRIPTION
For certain keyboard layout (like the German or the French keyboard layout), key commands containing `[` or `]` are not accessible (since they themselves require the use of certain modifiers).

In Safari for iOS, the keyboard shortcut for "Back" is listed as `CMD + [`. To work around this issue for the keyboard layouts mentioned above, they simply provide an alternative (non-discoverable) key command, which uses the arrow keys (`CMD + left arrow` for "Back", `CMD + right arrow` for "Forward"). This PR adds similar key commands for `prevShell:` and `nextShell:`. This might serve as temporary fix until the new keyboard system (mentioned in #496) is ready for showtime.

This PR addresses issues mentioned in #419 and #496.

(Sorry for not really being able to test it, but I had problems with the build system. But the fix seemed pretty straight forward. Happy holidays everyone ❤️)