### PR TITLE
Update copyright date to 2019 in about screen

### DIFF
--- a/Settings/ViewControllers/About/about.html
+++ b/Settings/ViewControllers/About/about.html
@@ -14,7 +14,7 @@
       <div class="container">
 	<div class="row">
 	  <div class="twelve column">
-	    <h4>Copyright © 2016 The Blink Shell Project</h4>
+	    <h4>Copyright © 2019 The Blink Shell Project</h4>
 	    <p>Thank you for supporting Blink! Blink Shell is fully Open Source Software. You are welcome to use it, modify it and redistribute it under certain conditions, specified under the terms of the GNU General Public License. In addition, Blink is also subject to certain additional terms under the GNU GPL version 3 section 7.</p>
 	  </div>
 	</div>


### PR DESCRIPTION
Just compiled and deployed.  Happen to notice this year were a few years off.