### PR TITLE
Updating most URLs to https to promote security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Blink Shell for iOS
-Do Blink! [Blink](http://blink.sh) is the first professional, desktop-grade terminal for iOS that leverages the support of Mosh and SSH. Thus, we can unequivocally guarantee stable connections, lightning-fast speeds, and full configurations. It can and should be your all-day-long tool.
+Do Blink! [Blink](https://blink.sh) is the first professional, desktop-grade terminal for iOS that leverages the support of Mosh and SSH. Thus, we can unequivocally guarantee stable connections, lightning-fast speeds, and full configurations. It can and should be your all-day-long tool.
 
 We did not create another terminal to fix your website on the go. Blink was built as a professional grade product from the onset. We started by analyzing what the must-haves were and we ended up grounding Blink on these three concepts:
 - Fast rendering: dmesg in your Unix server should be instantaneous. We can't wait even a second to render. We didn't need to reinvent the wheel to make this happen. We simply used Chromium's HTerm to ensure that rendering is perfect and fast, even with those special, tricky encodings.
@@ -13,7 +13,7 @@ But, Blink is much more. Please read on:
 - Configure your Blink connections by adding your own Hosts and RSA Encryption keys. Everything will look familiar and you get to work, fast!
 - We've incorporated SplitView, for those necessary Google searches and chats with coworkers.
 
-For more information, please visit [Blink Shell](http://blink.sh).
+For more information, please visit [Blink Shell](https://blink.sh).
 
 # Additions: 
 
@@ -63,7 +63,7 @@ setenv SSL_CERT_FILE = $HOME/Documents/cacert.pem
 If you want to change them permanently, it's probably best to edit `MCPSession.m`.
 
 # Obtaining Blink
-Blink is available now on the [AppStore](http://itunes.apple.com/app/id1156707581). Check it out!
+Blink is available now on the [AppStore](https://itunes.apple.com/app/id1156707581). Check it out!
 
 If you would like to participate on its development, we would love to have you on board! There are two ways to collaborate with the project: you can download and build Blink yourself, or you can request an invitation to help us test future versions (on the raw branch). If you want to participate on the testing, follow and tweet us [@BlinkShell](https://twitter.com/BlinkShell) about your usage scenarios. Invitations will be sent out in waves, please be patient if you do not receive yours immediately.
 
@@ -104,6 +104,6 @@ Our UI is very straightforward and optimizes the experience on touch devices for
 # Attributions
 - [Mosh](https://mosh.org) was written by Keith Winstein, along with Anders Kaseorg, Quentin Smith, Richard Tibbetts, Keegan McAllister, and John Hood.
 - This product includes software developed by the OpenSSL Project
-for use in the OpenSSL Toolkit. (http://www.openssl.org/).
+for use in the OpenSSL Toolkit. (https://www.openssl.org/).
 - [Libssh2](https://www.libssh2.org)
 - Entypo pictograms by Bruce Daniel www.entypo.com.


### PR DESCRIPTION
Entypo.com has an invalid SSL config (as does blink.sh but that one should be easy to fix).

https://blink.sh is presenting a Github certificate and complaining that it doesn’t match the current domain which means the site probably doesn’t have the CNAME and repository settings set up correctly to request one for the custom domain.

After digging in a little more it appears the current configuration of the site is setting the CNAME as www.blink.sh rather than the bare domain. I’m not sure who is the registrar for blink.sh but it should be fairly easy to make a new CNAME record there for www.blink.sh to point to blink.sh and then just set up the GitHub Pages CNAME file to use blink.sh. Few people that I’ve interacted with still say or type `www` so I think this might be the best route.

https://help.github.com/en/github/working-with-github-pages/securing-your-github-pages-site-with-https