### PR TITLE
Add option to bind ~ and ± keys

### DIFF
--- a/KB/Native/Model/KeyBindingAction.swift
+++ b/KB/Native/Model/KeyBindingAction.swift
@@ -151,6 +151,8 @@ enum KeyBindingAction: Codable, Identifiable {
       .hex("3C", comment: "Press <"),
       .hex("3E", comment: "Press >"),
       .hex("A7", comment: "Press §"),
+      .hex("B1", comment: "Press ±"),
+      .hex("7E", comment: "Press ~"),
       .hex("7C", comment: "Press |"),
       .hex("5C", comment: "Press \\"),
     ]


### PR DESCRIPTION
On some international keyboards, the keys for `/\~ and §/± are interchanged. This patch adds the shifted versions (\~ and ±), enabling swapping them completely the other way around. (Before this change it was only possible to swap the non-shifted versions.)