### PR TITLE
Support for ssh:// URL Schemes & brought back x-callback-url

### DIFF
--- a/Blink/Info.plist
+++ b/Blink/Info.plist
@@ -86,6 +86,7 @@
 			<string>Blink</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
+				<string>ssh</string>
 				<string>blinkshell</string>
 			</array>
 		</dict>

--- a/Blink/SceneDelegate.swift
+++ b/Blink/SceneDelegate.swift
@@ -98,7 +98,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     // Handle ssh:// URL scheme
     if let sshUrlScheme = URLContexts.first(where: { $0.url.absoluteString.starts(with: "ssh://")})?.url {
-      dump(sshUrlScheme)
       
       var sshCommand = "ssh"
       
@@ -116,21 +115,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         sshCommand += "\(host)"
       }
       
-      let spCtrl = _spCtrl
-      
-      guard let term = spCtrl.currentTerm() else {
+      guard let term = _spCtrl.currentTerm() else {
         return
       }
       
-      spCtrl.focusOnShellAction()
+      _spCtrl.focusOnShellAction()
       
       if term.isRunningCmd() {
         // If a SSH/mosh connection is already open in the current terminal shell
         // create a new one and then write the SSH command
         
-        spCtrl.newShellAction()
+        _spCtrl.newShellAction()
         
-        guard let term = spCtrl.currentTerm() else {
+        guard let term = _spCtrl.currentTerm() else {
           return
         }
         
@@ -157,21 +154,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
           return
         }
         
-        if let xCancel = items.filter({ $0.name == "x-cancel" }).first?.value {
+        if let xCancel = items.first(where: { $0.name == "x-cancel" })?.value {
           xCancelURL = URL(string: xCancel)
         }
 
-        if let xError = items.filter({ $0.name == "x-error" }).first?.value {
+        if let xError = items.first(where: { $0.name == "x-error" })?.value {
           xErrorURL = URL(string: xError)
         }
         
-        if let xSuccess = items.filter({ $0.name == "x-success" }).first?.value {
+        if let xSuccess = items.first(where: { $0.name == "x-success" })?.value {
           xSuccessURL = URL(string: xSuccess)
         }
         
         if !BKDefaults.isXCallBackURLEnabled() {
           if let xCancelURL = xCancelURL {
-            UIApplication.shared.open(xCancelURL, options: [:])
+            blink_openurl(xCancelURL)
           }
         }
         
@@ -179,7 +176,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // key field present that is needed to allow URL actions
         guard let keyItem: String = items.filter({ $0.name == "key" }).first?.value else {
           if let xCancelURL = xCancelURL {
-            UIApplication.shared.open(xCancelURL, options: [:])
+            blink_openurl(xCancelURL)
           }
           return
         }
@@ -189,7 +186,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // the correct key set
         if keyItem != BKDefaults.xCallBackURLKey() {
           if let xCancelURL = xCancelURL {
-            UIApplication.shared.open(xCancelURL, options: [:])
+            blink_openurl(xCancelURL)
           }
           
           return
@@ -197,7 +194,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let cmdItem: String = items.filter({ $0.name == "cmd" }).first?.value else {
           if let xErrorURL = xErrorURL {
-            UIApplication.shared.open(xErrorURL, options: [:])
+            blink_openurl(xErrorURL)
           }
           return
         }
@@ -206,7 +203,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         guard let term = spCtrl.currentTerm() else {
           if let xErrorURL = xErrorURL {
-            UIApplication.shared.open(xErrorURL, options: [:])
+            blink_openurl(xErrorURL)
           }
           return
         }
@@ -221,7 +218,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
           
           guard let term = spCtrl.currentTerm() else {
             if let xErrorURL = xErrorURL {
-              UIApplication.shared.open(xErrorURL, options: [:])
+              blink_openurl(xErrorURL)
             }
             return
           }

--- a/Blink/SceneDelegate.swift
+++ b/Blink/SceneDelegate.swift
@@ -118,7 +118,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         return
       }
       
-      // A SSH/mosh connection is open
+      spCtrl.focusOnShellAction()
+      
+      // If SSH/mosh connection is already open in the current terminal shell
+      // create a new one and then write the SSH command
       if term.isRunningCmd() {
         
         spCtrl.newShellAction()

--- a/Blink/SceneDelegate.swift
+++ b/Blink/SceneDelegate.swift
@@ -112,15 +112,28 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         sshCommand += "\(host)"
       }
       
-      dump(sshCommand)
-      
       let spCtrl = _spCtrl
       
       guard let term = spCtrl.currentTerm() else {
         return
       }
       
-      term.termDevice.write(sshCommand)
+      // A SSH/mosh connection is open
+      if term.isRunningCmd() {
+        
+        spCtrl.newShellAction()
+        
+        guard let term = spCtrl.currentTerm() else {
+          return
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+          term.termDevice.write(sshCommand)
+        }
+        
+      } else {
+          term.termDevice.write(sshCommand)
+      }
     }
   }
   

--- a/Blink/SceneDelegate.swift
+++ b/Blink/SceneDelegate.swift
@@ -399,8 +399,6 @@ extension SceneDelegate {
     if let xSuccess = items.first(where: { $0.name == "x-success" })?.value {
       xSuccessURL = URL(string: xSuccess)
     }
-    
-    dump(xCallbackUrl.host)
         
     guard case xCallbackUrl.host = "run" else {
       if let xErrorURL = xErrorURL {
@@ -460,7 +458,7 @@ extension SceneDelegate {
        // No running command or shell found running, run the SSH command on the
        // available shell
       term.xCallbackLineSubmitted(cmdItem, xSuccessURL)
-       return;
+      return
     }
     
     // If a SSH/mosh connection is already open in the current terminal shell

--- a/Blink/SceneDelegate.swift
+++ b/Blink/SceneDelegate.swift
@@ -91,6 +91,39 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
   }
   
+
+  /// Handle opened URL schemes for iOS devices that are over iOS 13
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    
+    if let sshUrlScheme = URLContexts.first(where: { $0.url.absoluteString.starts(with: "ssh://")})?.url {
+      dump(sshUrlScheme)
+      
+      var sshCommand = "ssh"
+      
+      if let port = sshUrlScheme.port {
+        sshCommand += " -p \(port)"
+      }
+      
+      if let username = sshUrlScheme.user {
+        sshCommand += " \(username)@"
+      }
+      
+      if let host = sshUrlScheme.host {
+        sshCommand += "\(host)"
+      }
+      
+      dump(sshCommand)
+      
+      let spCtrl = _spCtrl
+      
+      guard let term = spCtrl.currentTerm() else {
+        return
+      }
+      
+      term.termDevice.write(sshCommand)
+    }
+  }
+  
   func scene(
     _ scene: UIScene,
     willConnectTo session: UISceneSession,

--- a/Blink/TermController.swift
+++ b/Blink/TermController.swift
@@ -264,14 +264,6 @@ class TermController: UIViewController {
 }
 
 extension TermController: SessionDelegate {
-  func xCallbackFinished(_ xCallbackSuccessUrl: URL!) {
-    if let xCallbackSuccessUrl = xCallbackSuccessUrl {
-      DispatchQueue.main.async {
-        UIApplication.shared.open(xCallbackSuccessUrl, options: [:])
-      }
-    }
-  }
-  
   public func sessionFinished() {
     if _sessionParams.hasEncodedState() {
       _session?.delegate = nil

--- a/Blink/TermController.swift
+++ b/Blink/TermController.swift
@@ -264,6 +264,13 @@ class TermController: UIViewController {
 }
 
 extension TermController: SessionDelegate {
+  func xCallbackFinished(_ xCallbackSuccessUrl: URL!) {
+    if let xCallbackSuccessUrl = xCallbackSuccessUrl {
+      DispatchQueue.main.async {
+        UIApplication.shared.open(xCallbackSuccessUrl, options: [:])
+      }
+    }
+  }
   
   public func sessionFinished() {
     if _sessionParams.hasEncodedState() {
@@ -356,6 +363,10 @@ extension TermController: TermDeviceDelegate {
   
   public func viewController() -> UIViewController! {
     return self
+  }
+  
+  public func xCallbackLineSubmitted(_ line: String!, _ successUrl: URL? = nil) {
+    _session?.enqueueXCallbackCommand(line, xCallbackSuccessUrl: successUrl)
   }
   
   public func lineSubmitted(_ line: String!) {

--- a/Blink/TermController.swift
+++ b/Blink/TermController.swift
@@ -357,7 +357,7 @@ extension TermController: TermDeviceDelegate {
     return self
   }
   
-  public func xCallbackLineSubmitted(_ line: String!, _ successUrl: URL? = nil) {
+  public func xCallbackLineSubmitted(_ line: String, _ successUrl: URL? = nil) {
     _session?.enqueueXCallbackCommand(line, xCallbackSuccessUrl: successUrl)
   }
   

--- a/Sessions/MCPSession.h
+++ b/Sessions/MCPSession.h
@@ -45,6 +45,7 @@
 - (void)unregisterSSHClient:(SSHClient *)sshClient;
 
 - (void)enqueueCommand:(NSString *)cmd;
+- (void)enqueueXCallbackCommand:(NSString *)cmd xCallbackSuccessUrl:(NSURL *)xCallbackSuccessUrl;
 - (bool)isRunningCmd;
 
 - (void)updateAllowedPaths;

--- a/Sessions/MCPSession.m
+++ b/Sessions/MCPSession.m
@@ -126,7 +126,11 @@
 */
 - (void)enqueueXCallbackCommand:(NSString *)cmd xCallbackSuccessUrl:(NSURL *)xCallbackSuccessUrl {
   [self enqueueCommand:cmd];
-  blink_openurl(xCallbackSuccessUrl);
+  
+  dispatch_async(_cmdQueue, ^{
+    blink_openurl(xCallbackSuccessUrl);
+  });
+  
 }
 
 - (void)enqueueCommand:(NSString *)cmd {

--- a/Sessions/MCPSession.m
+++ b/Sessions/MCPSession.m
@@ -118,6 +118,21 @@
   });
 }
 
+/*!
+ @brief Enqueue a new command coming from a x-callback-url
+ @discussion Accepts the x-callback-url and the x-success URL to call after a successful command completion
+ @param cmd Command to be executed
+ @param xCallbackSuccessUrl Success URL of the original application (like Shortcuts) to return to after reunning the command
+*/
+- (void)enqueueXCallbackCommand:(NSString *)cmd xCallbackSuccessUrl:(NSURL *)xCallbackSuccessUrl {
+  [self enqueueCommand:cmd];
+  
+  dispatch_async(_cmdQueue, ^{
+    [self.delegate xCallbackFinished:xCallbackSuccessUrl];
+  });
+  
+}
+
 - (void)enqueueCommand:(NSString *)cmd {
   if (_cmdStream) {
     [_device writeInDirectly:[NSString stringWithFormat: @"%@\n", cmd]];

--- a/Sessions/MCPSession.m
+++ b/Sessions/MCPSession.m
@@ -126,11 +126,7 @@
 */
 - (void)enqueueXCallbackCommand:(NSString *)cmd xCallbackSuccessUrl:(NSURL *)xCallbackSuccessUrl {
   [self enqueueCommand:cmd];
-  
-  dispatch_async(_cmdQueue, ^{
-    blink_openurl(xCallbackSuccessUrl);
-  });
-  
+  blink_openurl(xCallbackSuccessUrl);
 }
 
 - (void)enqueueCommand:(NSString *)cmd {

--- a/Sessions/MCPSession.m
+++ b/Sessions/MCPSession.m
@@ -119,7 +119,7 @@
 }
 
 /*!
- @brief Enqueue a new command coming from a x-callback-url
+ @brief Enqueue a new command coming from a x-callback-url. After completing successfully return to the
  @discussion Accepts the x-callback-url and the x-success URL to call after a successful command completion
  @param cmd Command to be executed
  @param xCallbackSuccessUrl Success URL of the original application (like Shortcuts) to return to after reunning the command
@@ -128,7 +128,7 @@
   [self enqueueCommand:cmd];
   
   dispatch_async(_cmdQueue, ^{
-    [self.delegate xCallbackFinished:xCallbackSuccessUrl];
+    blink_openurl(xCallbackSuccessUrl);
   });
   
 }

--- a/Sessions/Session.h
+++ b/Sessions/Session.h
@@ -40,11 +40,6 @@
 @protocol SessionDelegate
 
 - (void)sessionFinished;
-/*!
-  @brief Open the original app that called the x-callback-url after a successful execution. If the x-callback-url is called from an app like shortcuts it will have a non nil xCallbackSuccessUrl to return to that app later. If it's called from Safari, for example, it won't as it doesn't need to return to that app after the command is executed.
-  @param xCallbackSuccessUrl x-success URL of the original app
- */
-- (void)xCallbackFinished:(NSURL *)xCallbackSuccessUrl;
 
 @end
 

--- a/Sessions/Session.h
+++ b/Sessions/Session.h
@@ -40,6 +40,11 @@
 @protocol SessionDelegate
 
 - (void)sessionFinished;
+/*!
+  @brief Open the original app that called the x-callback-url after a successful execution. If the x-callback-url is called from an app like shortcuts it will have a non nil xCallbackSuccessUrl to return to that app later. If it's called from Safari, for example, it won't as it doesn't need to return to that app after the command is executed.
+  @param xCallbackSuccessUrl x-success URL of the original app
+ */
+- (void)xCallbackFinished:(NSURL *)xCallbackSuccessUrl;
 
 @end
 


### PR DESCRIPTION
* `ssh://` links can be opened directly in Blink Shell. For example, `ssh://javierdemartin@192.168.1.99:22` will open Blink Shell and show the following command `ssh -p 22 javierdemartin@192.168.1.99`. Also, these links can be opened from a QR code.
* x-callback-urls are now working again