### PR TITLE
GitHub Actions: Enable framework caching and generate unsigned debug .ipa artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,23 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: true
+
     - name: xcode-select
       run: sudo xcode-select -s /Applications/Xcode_11.4.1.app
-    - name: get frameworks
-      run: ./get_frameworks.sh
-    - name: actual build
-      run: set -o pipefail && xcodebuild -project Blink.xcodeproj -scheme Blink -sdk iphoneos -configuration Debug clean build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=NO | tee build.log | xcpretty
 
+    - name: use cache
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: Frameworks
+        key: ${{ runner.os }}-${{ hashFiles('get_frameworks.sh') }}
+
+    - name: get frameworks
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: ./get_frameworks.sh
+
+    - name: actual build
+      run: set -o pipefail && xcodebuild archive -project Blink.xcodeproj -scheme Blink -sdk iphoneos -configuration Debug clean build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=NO | tee build.log | xcpretty

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,17 @@ jobs:
 
     - name: actual build
       run: set -o pipefail && xcodebuild archive -project Blink.xcodeproj -scheme Blink -sdk iphoneos -configuration Debug clean build CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=NO | tee build.log | xcpretty
+
+    - name: generate unsigned debug ipa
+      run: |
+        cd ~
+        mkdir Payload
+        mv ~/Library/Developer/Xcode/Archives/*/*/Products/Applications/Blink.app ~/Payload/
+        zip -r Payload.zip Payload
+        mv Payload.zip Blink.ipa
+
+    - name: upload ipa
+      uses: actions/upload-artifact@v2.2.0
+      with:
+        name: 'BlinkShell'
+        path: ~/Blink.ipa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
         cd ~
         mkdir Payload
         mv ~/Library/Developer/Xcode/Archives/*/*/Products/Applications/Blink.app ~/Payload/
-        zip -r Payload.zip Payload
-        mv Payload.zip Blink.ipa
-
+        zip -r Blink.ipa Payload
     - name: upload ipa
       uses: actions/upload-artifact@v2.2.0
       with:


### PR DESCRIPTION
Commit [22ff35f](https://github.com/blinksh/blink/commit/22ff35f738b43e8efe7d8522d98030c2ff1d146d) adds support for GitHub Actions caching. This should speed up builds a little bit by skipping the download of the frameworks every time a job is run, as long as the frameworks don't change. Once DEPS_VERSION in get_frameworks.sh changes (or anything in that file), the cache will not be used and the frameworks will be redownloaded and saved into a cache if the job completes successfully.

Commit [6580c28](https://github.com/blinksh/blink/commit/6580c289779de53cc383e17a4496d851f257bc9e) generates debug .ipa files that are unsigned. It is then uploaded to GitHub Actions as an artifact. Useful for testing, you can just sign it and put it right on to a real device.