### PR TITLE
Add the `--experimental-remote-ip` option to the `mosh` command

### DIFF
--- a/Sessions/SessionParams.swift
+++ b/Sessions/SessionParams.swift
@@ -70,6 +70,7 @@ import UIKit
   @objc var predictionMode: String? = nil
   @objc var startupCmd: String? = nil
   @objc var serverPath: String? = nil
+  @objc var experimentalRemoteIp: String? = nil
   
   override init() {
     super.init()


### PR DESCRIPTION
Fixes #1127 

This pull request adds the `--experimental-remote-ip` option to the `mosh` command. The possible values for the argument are:
- `--experimental-remote-ip=remote`: mosh-client will connect to the IP provided by the server's `SSH_CONNECTION` environment variable.
- `--experimental-remote-ip=local`:  mosh resolves the hostname given on its command line, and uses that address for both ssh and Mosh connections. (Currently, this is the only behavior available in Blink.)

The default value is `--experimental-remote-ip=remote`.