### PR TITLE
Use relative links (instead of absolute links) when linking from README.md to BUILD.md and vice versa

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,10 @@
 # Building
 We provide you with two ways to compile and install Blink Shell. This instructions will refer to assembling
 a full Blink Shell, compiling libraries and resources yourself. Due to the many dependencies that compose
-Blink Shell, this is the recommended but not shortest method. You can also clone Blink and obtain a "ready to go"
-tar.gz with all the dependencies as described on [home](https://github.com/blinksh/blink)
+Blink Shell, this is the recommended but not shortest method.
+
+You can also clone Blink and obtain a "ready to go"
+tar.gz with all the dependencies as described in the ["Build" section of the README.md file](README.md#build).
 
 ## Requirements
 Please note that to compile and install Blink in your personal

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ git clone --recursive https://github.com/blinksh/blink.git && \
 
 This will download Blink and the associated frameworks: `libssh2`, `OpenSSL`, `libmoshios`, `protobuf` and `ios_system`. 
 
-Although this is the quickest method to get you up and running, if you would like to compile all libraries and resources yourself, refer to [BUILD](https://github.com/blinksh/blink/blob/master/BUILD.md). Please let us know if you find any issues. Blink is a complex project with multiple low level dependencies and we are still looking for ways to simplify and automate the full compilation process.
+Although this is the quickest method to get you up and running, if you would like to compile all libraries and resources yourself, refer to the [BUILD.md](BUILD.md) file. Please let us know if you find any issues. Blink is a complex project with multiple low level dependencies and we are still looking for ways to simplify and automate the full compilation process.
 
 # Using Blink
 Our UI is very straightforward and optimizes the experience on touch devices for the really important part, the terminal. You will jump right into a very simple shell, so you will know what to do. Here are a few more tricks:


### PR DESCRIPTION
This pull request makes the following changes:
1. Use relative links (instead of absolute links) when linking from README.md to BUILD.md and vice versa.
2. Link to a specific subsection of README.md