### PR TITLE
Call setNeedsLayout() after hiding UITextInputAssistantItem

### DIFF
--- a/Blink/SmarterKeys/SmarterTermInput.swift
+++ b/Blink/SmarterKeys/SmarterTermInput.swift
@@ -280,6 +280,7 @@ class CaretHider {
     }
     item.leadingBarButtonGroups = []
     item.trailingBarButtonGroups = []
+    setNeedsLayout()
   }
   
   override func _keyboardDidChangeFrame(_ notification: Notification) {


### PR DESCRIPTION
Fixes #1125

I confirmed that this change fixed the issue by [this procedure](https://github.com/blinksh/blink/issues/1125#issuecomment-731744035).