### PR TITLE
Fix small typo in Create a Font

### DIFF
--- a/Resources/FontsAndThemes.md
+++ b/Resources/FontsAndThemes.md
@@ -69,13 +69,13 @@ t.prefs_.set('cursor-blink', true);
     font-family: "Fira Code";
     font-style: normal;
     font-weight: 200;
-    src: url(data:font/woff;charset-utf-8;base64,<base64 dump>);
+    src: url(data:font/woff;charset=utf-8;base64,<base64 dump>);
 }
 @font-face {
     font-family: "Fira Code";
     font-style: normal;
     font-weight: 400;
-    src: url(data:font/woff;charset-utf-8;base64,<base64 dump>);
+    src: url(data:font/woff;charset=utf-8;base64,<base64 dump>);
 }
 @font-face {
     font-family: "Fira Code";


### PR DESCRIPTION
Updated first two `src` examples to replace `charset-utf-8` with `charset=utf-8`.