### PR TITLE
Fixed unable to import private key from files #1106

### DIFF
--- a/Settings/ViewControllers/BKPubKey/BKPubKeyViewController.m
+++ b/Settings/ViewControllers/BKPubKey/BKPubKeyViewController.m
@@ -364,11 +364,12 @@ enum SshKeyImportOrigin {
   
   for (NSURL *fileUrl in urls) {
     // Make the resource we're trying to access accessible to the app.
-    [fileUrl startAccessingSecurityScopedResource];
-    NSString *keyString = [NSString stringWithContentsOfURL:fileUrl encoding:NSUTF8StringEncoding error:NULL];
-    [fileUrl stopAccessingSecurityScopedResource];
-    
-    [self _importKeyFromString:keyString importOrigin:(FROM_FILE)];
+    if ([fileUrl startAccessingSecurityScopedResource]) {
+      NSString *keyString = [NSString stringWithContentsOfURL:fileUrl encoding:NSUTF8StringEncoding error:NULL];
+      [fileUrl stopAccessingSecurityScopedResource];
+      
+      [self _importKeyFromString:keyString importOrigin:(FROM_FILE)];
+    }
   }
 }
 

--- a/Settings/ViewControllers/BKPubKey/BKPubKeyViewController.m
+++ b/Settings/ViewControllers/BKPubKey/BKPubKeyViewController.m
@@ -363,9 +363,11 @@ enum SshKeyImportOrigin {
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
   
   for (NSURL *fileUrl in urls) {
-    
+    // Make the resource we're trying to access accessible to the app.
+    [fileUrl startAccessingSecurityScopedResource];
     NSString *keyString = [NSString stringWithContentsOfURL:fileUrl encoding:NSUTF8StringEncoding error:NULL];
-
+    [fileUrl stopAccessingSecurityScopedResource];
+    
     [self _importKeyFromString:keyString importOrigin:(FROM_FILE)];
   }
 }

--- a/Settings/ViewControllers/BKPubKey/BKPubKeyViewController.m
+++ b/Settings/ViewControllers/BKPubKey/BKPubKeyViewController.m
@@ -364,12 +364,15 @@ enum SshKeyImportOrigin {
   
   for (NSURL *fileUrl in urls) {
     // Make the resource we're trying to access accessible to the app.
-    if ([fileUrl startAccessingSecurityScopedResource]) {
-      NSString *keyString = [NSString stringWithContentsOfURL:fileUrl encoding:NSUTF8StringEncoding error:NULL];
-      [fileUrl stopAccessingSecurityScopedResource];
-      
-      [self _importKeyFromString:keyString importOrigin:(FROM_FILE)];
+    if ([fileUrl startAccessingSecurityScopedResource] == NO) {
+      continue;
     }
+    
+    NSString *keyString = [NSString stringWithContentsOfURL:fileUrl encoding:NSUTF8StringEncoding error:NULL];
+    [fileUrl stopAccessingSecurityScopedResource];
+    
+    [self _importKeyFromString:keyString importOrigin:(FROM_FILE)];
+    
   }
 }
 


### PR DESCRIPTION
Missing NSURL.startAccessingSecurityScopedResource led to errors importing private keys from a file