### PR TITLE
Patch hterm to treat DEC mode 1003 as 1002

### DIFF
--- a/Resources/hterm_all.patches.js
+++ b/Resources/hterm_all.patches.js
@@ -54,3 +54,15 @@ hterm.Terminal.prototype.setCursorVisible = function(state) {
     }
   }
 };
+
+// NOTE(@nanzhong) hterm does not support DEC mode 1003 (any mouse event reporting mode).
+// DEC mode 1003 and DEC mode 1002 (which hterm does support) are almost identical. The only difference is that mode 1003 includes mouse movement tracking events which are rarely used.
+// This patches hterm to treat DEC mode 1003 the same as DEC mode 1002.
+
+hterm.VT.prototype.setDECMode_original = hterm.VT.prototype.setDECMode;
+hterm.VT.prototype.setDECMode = function(code, state) {
+  if (code === "1003") {
+    code = "1002";
+  }
+  hterm.VT.prototype.setDECMode_original.call(this, code, state);
+};


### PR DESCRIPTION
hterm does not support DEC mode 1003 for reporting mouse events, and this is [not something that upstream is currently thinking about implementing](https://chromium.googlesource.com/apps/libapps/+/master/hterm/doc/ControlSequences.md#motion-event-tracking). This PR patches hterm to treat DEC mode 1003 the same as DEC mode 1002. The difference between the two modes is that 1003 also include mouse movement tracking events (which in practice are rarely used). This change bring better graceful degradation than the upstream behaviour which is reporting no mouse events.

## Context

I noticed a couple months ago that `xterm-mouse-mode` in emacs (built from master) stopped working as expected (no mouse events) only under mosh. Digging into it some more it seems that [emacs changed from using DEC mode 1002 to DEC mode 1002 for mouse reporting](https://github.com/emacs-mirror/emacs/commit/0695c9e8599b5036a80361571e7cb0ea9fdead99).

It turns out it's the interaction between how hterm, mosh, and emacs handle the mouse reporting modes...
- hterm supports a subset of these modes 9 (legacy X10), 1000 (click reporting), and 1002 (click + drag).
- mosh supports them all
- emacs (current master) incorrectly tries to set mode 1000 followed by 1003

These mouse reporting modes are mutually exclusive with the last one taking precedence. So in reality emacs' behaviour _should_ be equivalent to just setting 1003 (I can look into contributing an emacs to address this).

The issue is that because hterm doesn't support mode 1003; that gets ignored. So with plain ssh, hterm sees mode 1000, ignores 1003. So emacs gets basic mouse click event reporting. With mosh, because 1003 is the last mode that emacs sets, mosh correctly only keeps mode 1003 in the framebuffer; hterm ignores 1003 so no mouse events are reported.

From discord discussion @ https://discord.com/channels/441939332442619905/442378162425298954/811092562017386506: