### PR TITLE
Fix incorrect mosh ssh argument order

### DIFF
--- a/Sessions/MoshSession.m
+++ b/Sessions/MoshSession.m
@@ -368,8 +368,8 @@ void __state_callback(const void *context, const void *buffer, size_t size) {
   
   BOOL useIPFromSSHConnectionEnv = [@"remote" isEqual:self.sessionParams.experimentalRemoteIp];
   if (useIPFromSSHConnectionEnv) {
-    NSString * echoSshConnectionCommand = @"echo \"\" && echo \"MOSH SSH_CONNECTION $SSH_CONNECTION\" &&";
-    sshArgs = [@[ssh, @"-o compression=no", sshTTY ? @"-t" : @"-T", userHost, echoSshConnectionCommand, @"--", command] mutableCopy];
+    NSString *commandWithEcho = [NSString stringWithFormat:@"echo \"MOSH SSH_CONNECTION $SSH_CONNECTION\" && %@", command];
+    sshArgs = [@[ssh, @"-o compression=no", sshTTY ? @"-t" : @"-T", userHost, @"--", commandWithEcho] mutableCopy];
   } else {
     sshArgs = [@[ssh, @"-o compression=no", sshTTY ? @"-t" : @"-T", userHost, @"--", command] mutableCopy];
   }


### PR DESCRIPTION
The -- argument that was introduced was incorrectly positioned between
the echo commands for printing ssh connection details and the
command.

This commit fixes the ordering. In addition, it cleans up the way the
command is constructed together with the echo commands.