### PR TITLE
Port #1202 to raw branch

### DIFF
--- a/Resources/hterm_all.patches.js
+++ b/Resources/hterm_all.patches.js
@@ -54,3 +54,15 @@ hterm.Terminal.prototype.setCursorVisible = function(state) {
     }
   }
 };
+
+// NOTE(@nanzhong) hterm does not support DEC mode 1003 (any mouse event reporting mode).
+// DEC mode 1003 and DEC mode 1002 (which hterm does support) are almost identical. The only difference is that mode 1003 includes mouse movement tracking events which are rarely used.
+// This patches hterm to treat DEC mode 1003 the same as DEC mode 1002.
+
+hterm.VT.prototype.setDECMode_original = hterm.VT.prototype.setDECMode;
+hterm.VT.prototype.setDECMode = function(code, state) {
+  if (code === "1003") {
+    code = "1002";
+  }
+  hterm.VT.prototype.setDECMode_original.call(this, code, state);
+};


### PR DESCRIPTION
I noticed that #1202 only existed on the `main` branch. This ports the change over the the `raw` branch so that future TestFlight releases will include the change.