### PR TITLE
Add xcconfig file, to avoid changing project.pbxproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Frameworks/openssl.framework
 ## Other
 *.moved-aside
 *.xcuserstate
+developer_setup.xcconfig
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Blink.xcodeproj/project.pbxproj
+++ b/Blink.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 		22A9494A2067FD5E003A0666 /* tar.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = tar.framework; sourceTree = "<group>"; };
 		22E1F3332036EE86001FCC5C /* openssl.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = openssl.framework; sourceTree = "<group>"; };
 		22E1F3342036EE86001FCC5C /* libssh2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = libssh2.framework; sourceTree = "<group>"; };
+		398D59F1260762B90066BDD3 /* developer_setup.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = developer_setup.xcconfig; sourceTree = "<group>"; };
 		803B99D62582869200DC99C8 /* BKNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKNotificationsView.swift; sourceTree = "<group>"; };
 		803B99E2258381B200DC99C8 /* SettingsHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHostingController.swift; sourceTree = "<group>"; };
 		85A34303200A837A009324F1 /* webfontloader.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = webfontloader.js; sourceTree = "<group>"; };
@@ -1362,6 +1363,7 @@
 		EA0BA1821C0CC57B00719C1A = {
 			isa = PBXGroup;
 			children = (
+				398D59F1260762B90066BDD3 /* developer_setup.xcconfig */,
 				D2C243F7238E44960082C69C /* KB */,
 				C9B2E0031D6B612300B89F69 /* Settings */,
 				D265FBBB2317DD3C0017EAC4 /* BlinkTests */,
@@ -1440,13 +1442,13 @@
 				TargetAttributes = {
 					D265FBB92317DD3C0017EAC4 = {
 						CreatedOnToolsVersion = 11.0;
-						DevelopmentTeam = HV2S48975V;
+						DevelopmentTeam = "$(TEAM_ID)";
 						ProvisioningStyle = Automatic;
 						TestTargetID = EA0BA18A1C0CC57B00719C1A;
 					};
 					EA0BA18A1C0CC57B00719C1A = {
 						CreatedOnToolsVersion = 7.1.1;
-						DevelopmentTeam = HV2S48975V;
+						DevelopmentTeam = "$(TEAM_ID)";
 						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -1864,7 +1866,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HV2S48975V;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1897,7 +1899,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = HV2S48975V;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = BlinkTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1912,6 +1914,7 @@
 		};
 		EA0BA1AB1C0CC57C00719C1A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 398D59F1260762B90066BDD3 /* developer_setup.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -1964,6 +1967,7 @@
 		};
 		EA0BA1AC1C0CC57C00719C1A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 398D59F1260762B90066BDD3 /* developer_setup.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -2025,7 +2029,7 @@
 				CURRENT_PROJECT_VERSION = 262;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = HV2S48975V;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2048,7 +2052,7 @@
 				);
 				MARKETING_VERSION = 13.5.12;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = Com.CarlosCabanero.BlinkShell;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID)";
 				PRODUCT_NAME = Blink;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -2069,7 +2073,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 262;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = HV2S48975V;
+				DEVELOPMENT_TEAM = "$(TEAM_ID)";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2089,7 +2093,7 @@
 				);
 				MARKETING_VERSION = 13.5.12;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = Com.CarlosCabanero.BlinkShell;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(BUNDLE_ID)";
 				PRODUCT_NAME = Blink;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRIP_STYLE = "non-global";

--- a/Blink/Blink.entitlements
+++ b/Blink/Blink.entitlements
@@ -8,7 +8,7 @@
 	<string>NSFileProtectionComplete</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
-		<string>iCloud.com.carloscabanero.blinkshell</string>
+		<string>iCloud.$(CLOUD_ID)</string>
 	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
@@ -17,14 +17,14 @@
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
-		<string>iCloud.com.carloscabanero.blinkshell</string>
+		<string>iCloud.$(CLOUD_ID)</string>
 	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)Com.CarlosCabanero.Blink</string>
-		<string>$(AppIdentifierPrefix)Com.CarlosCabanero.BlinkShell</string>
+		<string>$(AppIdentifierPrefix)$(KEYCHAIN_ID1)</string>
+		<string>$(AppIdentifierPrefix)$(KEYCHAIN_ID2)</string>
 	</array>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -81,13 +81,18 @@ We made a ton easier to build and install Blink yourself on your iOS devices thr
 git clone --recursive https://github.com/blinksh/blink.git && \
     cd blink && ./get_frameworks.sh && \
     rm -rf Blink.xcodeproj/project.xcworkspace/xcshareddata/
-```
-2. Open the project in XCode
-3. Before doing anything else, go into the capabilities for the project and turn off Push Notifications, iCloud, and Keychain Sharing
-4. Go to the General tab and change the bundle identifier to something that will work for your team
-5. Stay in the general tab and select your team under the "Signing" section
-6. Connect the device you want to build for and select it in Product -> Destination
-7. Build and run on the device
+
+2. Do the following
+cd blink
+cp template_setup.xcconfig developer_setup.xcconfig
+edit developer_setup.xcconfig (change apple developer id etc).
+
+3. Open the project in XCode
+
+3a. If you want to build without iCloud, Push Notificationa and/or Keychain sharing, Before doing anything else, go into the capabilities for the project and turn off Push Notifications, iCloud, and Keychain Sharing
+
+4. Connect the device you want to build for and select it in Product -> Destination
+5. Build and run on the device
 
 This will download Blink and the associated frameworks: `libssh2`, `OpenSSL`, `libmoshios`, `protobuf` and `ios_system`. 
 

--- a/template_setup.xcconfig
+++ b/template_setup.xcconfig
@@ -1,0 +1,24 @@
+//
+//  template_setup.xcconfig
+//     --> copied to developer_setup.xcconfig
+//
+//  Created by Jan Iversen on 20/03/2021.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// update TEAM_ID with your apple developer id
+TEAM_ID = HV2S48975V
+
+// BUNDLE_ID is used as name for BUNDLE_IDENTIFIER
+BUNDLE_ID = Com.CarlosCabanero.BlinkShell
+
+// CLOUD_ID is used as name for iCloud (prefix icloud. is added)
+CLOUD_ID = com.carloscabanero.blinkshell
+// if you want to build without iCloud, please remove the section in xCode
+
+// KEYCHAIN_ID is used as name for keychain
+KEYCHAIN_ID1 = Com.carloscabanero.blink
+KEYCHAIN_ID2 = Com.carloscabanero.blinkshell
+// if you want to build without keychain, please remove the section in xCode


### PR DESCRIPTION
Congratulations with the new build !!! it works like a charm.

I am a long time developer (since '77) doing a lot of C/C++/Python coding and sometimes Swift...and only when really pressed Java. I try to contribute to projects I find interesting (and have done so since I started).

I found it annoying to have to change project.pbxproj, so I made some slight changes, which I hope the project likes.
----
Instead of having developers changing in project.pbxproj, and run the risk that it is added in a commit, it is a lot easier to use xcconfig files.

This PR uses 2 files:
./template_developer_setup.xcconfig
which is stored in git, but not used. The developer in a new installation copies this file to:
./developer_setup.xcconfig
which is NOT stored in git, but in .gitignore. The developer replaces the apple developer id and such.

If a developer do not want to use keychain, push notification and/or iCloud, he/she needs to remove the section using Xcode.
-----

Having used Blink for a short while, I have seen 2 features I miss:
1) Name of the connection as a header line, with a different color
2) A dialog on startup, giving me a chance to connect to the defined hosts or go into the shell

But that is something I will try to do (unless you already have it planned).

Thanks for a super ssh client!!!!