### PR TITLE
Using BKConfig as an intermediary to generate proper configuration

### DIFF
--- a/Blink.xcodeproj/project.pbxproj
+++ b/Blink.xcodeproj/project.pbxproj
@@ -165,6 +165,11 @@
 		BDCB718D268E16CE007D7047 /* BlinkConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = BDCB718C268E16CE007D7047 /* BlinkConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BDCB718E268E173D007D7047 /* SSH.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07FABB8425C9AEC000E1CC2C /* SSH.framework */; };
 		BDCB7194268E175A007D7047 /* SSHConfig in Frameworks */ = {isa = PBXBuildFile; productRef = BDCB7193268E175A007D7047 /* SSHConfig */; };
+		BDD6D13A27594BF900E76F1F /* BlinkConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6D13927594BF900E76F1F /* BlinkConfigTests.swift */; };
+		BDD6D13B27594BF900E76F1F /* BlinkConfig.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDCB715E268E1577007D7047 /* BlinkConfig.framework */; };
+		BDD6D14527594E6500E76F1F /* BKSSHHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6D14427594E6500E76F1F /* BKSSHHost.swift */; };
+		BDD6D14727594E8700E76F1F /* SSHClientConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6D14627594E8700E76F1F /* SSHClientConfig.swift */; };
+		BDD6D149275951D900E76F1F /* BKGlobalSSHConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6D148275951D900E76F1F /* BKGlobalSSHConfig.swift */; };
 		BDF471BA268CD17B00A7A41B /* SSH.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07FABB8425C9AEC000E1CC2C /* SSH.framework */; };
 		C94437571D8311960096F84E /* BKResource.m in Sources */ = {isa = PBXBuildFile; fileRef = C94437561D8311960096F84E /* BKResource.m */; };
 		C94437601D831CD30096F84E /* Themes in Resources */ = {isa = PBXBuildFile; fileRef = C944375F1D831CD30096F84E /* Themes */; };
@@ -521,6 +526,13 @@
 			remoteGlobalIDString = 07FABB8325C9AEC000E1CC2C;
 			remoteInfo = SSH;
 		};
+		BDD6D13C27594BF900E76F1F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EA0BA1831C0CC57B00719C1A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BDCB715D268E1577007D7047;
+			remoteInfo = BlinkConfig;
+		};
 		BDF471BC268CD17B00A7A41B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = EA0BA1831C0CC57B00719C1A /* Project object */;
@@ -800,6 +812,11 @@
 		BDCB7175268E15A2007D7047 /* SEKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SEKey.swift; sourceTree = "<group>"; };
 		BDCB7176268E15A2007D7047 /* BKConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BKConfig.swift; sourceTree = "<group>"; };
 		BDCB718C268E16CE007D7047 /* BlinkConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlinkConfig.h; sourceTree = "<group>"; };
+		BDD6D13727594BF900E76F1F /* BlinkConfigTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BlinkConfigTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BDD6D13927594BF900E76F1F /* BlinkConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlinkConfigTests.swift; sourceTree = "<group>"; };
+		BDD6D14427594E6500E76F1F /* BKSSHHost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BKSSHHost.swift; sourceTree = "<group>"; };
+		BDD6D14627594E8700E76F1F /* SSHClientConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHClientConfig.swift; sourceTree = "<group>"; };
+		BDD6D148275951D900E76F1F /* BKGlobalSSHConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BKGlobalSSHConfig.swift; sourceTree = "<group>"; };
 		C94437551D8311960096F84E /* BKResource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BKResource.h; sourceTree = "<group>"; };
 		C94437561D8311960096F84E /* BKResource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BKResource.m; sourceTree = "<group>"; };
 		C944375F1D831CD30096F84E /* Themes */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Themes; sourceTree = "<group>"; };
@@ -1117,6 +1134,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BDD6D13427594BF900E76F1F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BDD6D13B27594BF900E76F1F /* BlinkConfig.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D218068425CC277900B98902 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1379,6 +1404,7 @@
 				BD9BF7E3262A6B0300B02074 /* SOCKS.swift */,
 				07FABBD325C9AF5F00E1CC2C /* SSHClient.swift */,
 				07FABBD925C9AF5F00E1CC2C /* SSHClient+KnownHostsHelpers.swift */,
+				BDD6D14627594E8700E76F1F /* SSHClientConfig.swift */,
 				07FABBD225C9AF5F00E1CC2C /* SSHError.swift */,
 				BD8D892125DC428300E55D9E /* SSHKeys.swift */,
 				07FABBDB25C9AF5F00E1CC2C /* SSHPortForward.swift */,
@@ -1585,9 +1611,11 @@
 				BDCB718C268E16CE007D7047 /* BlinkConfig.h */,
 				BDB8BEA726E008190093BF48 /* OwnAlertController.swift */,
 				BDCB7176268E15A2007D7047 /* BKConfig.swift */,
+				BDD6D148275951D900E76F1F /* BKGlobalSSHConfig.swift */,
 				BDCB7171268E15A1007D7047 /* BKHosts.h */,
 				BDCB716C268E15A1007D7047 /* BKHosts.m */,
 				BDCB716B268E15A0007D7047 /* BKHosts.swift */,
+				BDD6D14427594E6500E76F1F /* BKSSHHost.swift */,
 				BDCB716F268E15A1007D7047 /* BKPubKey.h */,
 				BDCB7174268E15A2007D7047 /* BKPubKey.m */,
 				BDCB7170268E15A1007D7047 /* BKPubKey.swift */,
@@ -1601,6 +1629,14 @@
 				BDCB7161268E1577007D7047 /* Info.plist */,
 			);
 			path = BlinkConfig;
+			sourceTree = "<group>";
+		};
+		BDD6D13827594BF900E76F1F /* BlinkConfigTests */ = {
+			isa = PBXGroup;
+			children = (
+				BDD6D13927594BF900E76F1F /* BlinkConfigTests.swift */,
+			);
+			path = BlinkConfigTests;
 			sourceTree = "<group>";
 		};
 		C989E53B1D6CC488003E0079 /* BKHosts */ = {
@@ -1962,6 +1998,7 @@
 				98271251262E4BDB00F883FA /* BlinkFileProvider */,
 				D2BF5F6D2659522C0070F839 /* BlinkIntents */,
 				BDCB715F268E1577007D7047 /* BlinkConfig */,
+				BDD6D13827594BF900E76F1F /* BlinkConfigTests */,
 				BDBFA3062728914F00C77798 /* BlinkCode */,
 				BDBFA3102728914F00C77798 /* BlinkCodeTests */,
 				0732F04F1D062BB300AB5438 /* Frameworks */,
@@ -1992,6 +2029,7 @@
 				BD9EA1C92718E19000874007 /* BlinkFileProviderUI.appex */,
 				BDBFA3052728914F00C77798 /* BlinkCode.framework */,
 				BDBFA30C2728914F00C77798 /* BlinkCodeTests.xctest */,
+				BDD6D13727594BF900E76F1F /* BlinkConfigTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2216,6 +2254,24 @@
 			productReference = BDCB715E268E1577007D7047 /* BlinkConfig.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		BDD6D13627594BF900E76F1F /* BlinkConfigTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BDD6D14327594BF900E76F1F /* Build configuration list for PBXNativeTarget "BlinkConfigTests" */;
+			buildPhases = (
+				BDD6D13327594BF900E76F1F /* Sources */,
+				BDD6D13427594BF900E76F1F /* Frameworks */,
+				BDD6D13527594BF900E76F1F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BDD6D13D27594BF900E76F1F /* PBXTargetDependency */,
+			);
+			name = BlinkConfigTests;
+			productName = BlinkConfigTests;
+			productReference = BDD6D13727594BF900E76F1F /* BlinkConfigTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D218068625CC277900B98902 /* AppKitBridge */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D218068A25CC277900B98902 /* Build configuration list for PBXNativeTarget "AppKitBridge" */;
@@ -2348,6 +2404,9 @@
 						CreatedOnToolsVersion = 12.5;
 						LastSwiftMigration = 1250;
 					};
+					BDD6D13627594BF900E76F1F = {
+						CreatedOnToolsVersion = 13.1;
+					};
 					D218068625CC277900B98902 = {
 						CreatedOnToolsVersion = 12.4;
 					};
@@ -2433,6 +2492,7 @@
 				BD9EA1C82718E19000874007 /* BlinkFileProviderUI */,
 				BDBFA3042728914F00C77798 /* BlinkCode */,
 				BDBFA30B2728914F00C77798 /* BlinkCodeTests */,
+				BDD6D13627594BF900E76F1F /* BlinkConfigTests */,
 			);
 		};
 /* End PBXProject section */
@@ -2540,6 +2600,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BDD6D13527594BF900E76F1F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D218068525CC277900B98902 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2633,6 +2700,7 @@
 				BD8D892325DC428300E55D9E /* SSHKeys.swift in Sources */,
 				07FABBE525C9AF5F00E1CC2C /* AuthMethods.swift in Sources */,
 				07FABBE025C9AF5F00E1CC2C /* Streams.swift in Sources */,
+				BDD6D14727594E8700E76F1F /* SSHClientConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2729,6 +2797,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDD6D149275951D900E76F1F /* BKGlobalSSHConfig.swift in Sources */,
 				D2DE9CA626EA1CC000A0B29C /* BKMiniLog.m in Sources */,
 				BDCB7179268E15A2007D7047 /* BKHosts.m in Sources */,
 				BDCB7182268E15A2007D7047 /* SEKey.swift in Sources */,
@@ -2739,6 +2808,15 @@
 				D238675426EA76E6003A82A1 /* OwnAlertController.swift in Sources */,
 				BDCB717F268E15A2007D7047 /* BlinkPaths.m in Sources */,
 				BDCB717B268E15A2007D7047 /* UICKeyChainStore.m in Sources */,
+				BDD6D14527594E6500E76F1F /* BKSSHHost.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BDD6D13327594BF900E76F1F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BDD6D13A27594BF900E76F1F /* BlinkConfigTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3041,6 +3119,11 @@
 			isa = PBXTargetDependency;
 			target = 07FABB8325C9AEC000E1CC2C /* SSH */;
 			targetProxy = BDCB7190268E173D007D7047 /* PBXContainerItemProxy */;
+		};
+		BDD6D13D27594BF900E76F1F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BDCB715D268E1577007D7047 /* BlinkConfig */;
+			targetProxy = BDD6D13C27594BF900E76F1F /* PBXContainerItemProxy */;
 		};
 		BDF471BD268CD17B00A7A41B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3880,6 +3963,79 @@
 			};
 			name = Release;
 		};
+		BDD6D13E27594BF900E76F1F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HV2S48975V;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = cc.carloscabanero.BlinkConfigTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BDD6D13F27594BF900E76F1F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HV2S48975V;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = cc.carloscabanero.BlinkConfigTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		D218068B25CC277900B98902 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4353,6 +4509,15 @@
 			buildConfigurations = (
 				BDCB7168268E1577007D7047 /* Debug */,
 				BDCB7169268E1577007D7047 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BDD6D14327594BF900E76F1F /* Build configuration list for PBXNativeTarget "BlinkConfigTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BDD6D13E27594BF900E76F1F /* Debug */,
+				BDD6D13F27594BF900E76F1F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Blink/Commands/ssh/SSHAgentAdd.swift
+++ b/Blink/Commands/ssh/SSHAgentAdd.swift
@@ -91,7 +91,7 @@ public class BlinkSSHAgentAdd: NSObject {
   let currentRunLoop = RunLoop.current
   
   public func start(_ argc: Int32, argv: [String]) -> Int32 {
-    let bkConfig = BKConfig(allHosts: BKHosts.allHosts(), allIdentities: BKPubKey.all())
+    let bkConfig = BKConfig()
     do {
       command = try BlinkSSHAgentAddCommand.parse(Array(argv[1...]))
     } catch {

--- a/Blink/Commands/ssh/SSHPool.swift
+++ b/Blink/Commands/ssh/SSHPool.swift
@@ -34,6 +34,7 @@ import Foundation
 import Combine
 import Dispatch
 
+import BlinkConfig
 import SSH
 
 
@@ -43,9 +44,13 @@ class SSHPool {
   
   private init() {}
 
-  static func dial(_ host: String, with config: SSHClientConfig, connectionOptions options: ConfigFileOptions, withProxy proxy: SSH.SSHClient.ExecProxyCommandCallback? = nil) -> AnyPublisher<SSH.SSHClient, Error> {
+  static func dial(_ host: String, 
+                   with config: SSHClientConfig, 
+                   withControlMaster: ControlMasterOption = .no, 
+                   withProxy proxy: SSH.SSHClient.ExecProxyCommandCallback? = nil) -> AnyPublisher<SSH.SSHClient, Error> {
+
     // Do not use an existing socket.
-    if !options.controlMaster {
+    if withControlMaster == .no {
       // TODO We may want a new socket, but still be able to manipulate it.
       // For now we will not allow that situation.
       return shared.startConnection(host, with: config, proxy: proxy, exposeSocket: false)

--- a/BlinkConfig/BKGlobalSSHConfig.swift
+++ b/BlinkConfig/BKGlobalSSHConfig.swift
@@ -1,0 +1,116 @@
+//////////////////////////////////////////////////////////////////////////////////
+//
+// B L I N K
+//
+// Copyright (C) 2016-2019 Blink Mobile Shell Project
+//
+// This file is part of Blink.
+//
+// Blink is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Blink is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Blink. If not, see <http://www.gnu.org/licenses/>.
+//
+// In addition, Blink is also subject to certain additional terms under
+// GNU GPL version 3 section 7.
+//
+// You should have received a copy of these additional terms immediately
+// following the terms and conditions of the GNU General Public License
+// which accompanied the Blink Source Code. If not, see
+// <http://www.github.com/blinksh/blink>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+import Foundation
+
+import SSHConfig
+
+
+public class BKGlobalSSHConfig: NSObject, NSSecureCoding {
+  let user: String
+
+  public static var supportsSecureCoding: Bool = true
+ 
+  @objc public init(user: String) {
+    self.user = user
+    
+    super.init()
+  }
+
+  public required init?(coder decoder: NSCoder) {
+    guard let user = decoder.decodeObject(of: [NSString.self], forKey: "user") as? String
+    else {
+      return nil
+    }
+
+    self.user = user
+  }
+
+  public func encode(with coder: NSCoder) {
+    coder.encode(user, forKey: "user")
+  }
+
+  // @objc public func save() {
+  //   do {
+  //     let data = try NSKeyedArchiver.archivedData(
+  //       withRootObject: self,
+  //       requiringSecureCoding: true
+  //     )
+
+  //     try data.write(to: BlinkPaths.globalSSHConfig,
+  //                    options: NSDataWritingAtomic | NSDataWritingFileProtectionNone)
+  //   } catch {
+  //     print(error)
+  //   }
+  // }
+
+  // public static func load() -> BKGlobalSSHConfig? {
+  //   do {
+  //     let data = try Data(contentsOf: BlinkPaths.globalSSHConfig)
+
+  //     return try NSKeyedUnarchiver.decodeObject(data) as? BKGlobalSSHConfig
+  //   } catch {
+  //     print(error)
+  //     return nil
+  //   }
+  // }
+
+  @objc public func saveFile() {
+    do {
+      let config = SSHConfig()
+
+      // TODO High level migration mechanism.
+      try config.add(alias: "*", cfg: [("User", self.user), 
+                                       ("ControlMaster", "auto"),
+                                       ("SendEnv", "LANG")])
+   
+      // Config does not currently allow for single lines
+      let configString = """
+Include ssh_config
+Include ../.ssh/config
+
+\(config.string())
+"""
+      guard let data = configString.data(using: .utf8),
+            let url = BlinkPaths.blinkGlobalSSHConfigFileURL()
+      else {
+        print("Could not write global ssh configuration")
+        return
+      }
+
+      try data.write(to: url)
+    } catch(let error) {
+      // TODO We could/should rely on a Log + Alert mechanism.
+      print(error.localizedDescription)
+    }
+  }
+}

--- a/BlinkConfig/BKHosts.h
+++ b/BlinkConfig/BKHosts.h
@@ -89,4 +89,20 @@ enum BKMoshPrediction {
 + (CKRecord *)recordFromHost:(BKHosts *)host;
 + (BKHosts *)hostFromRecord:(CKRecord *)hostRecord;
 + (instancetype)withiCloudId:(CKRecordID *)record;
+
+- (id)initWithAlias:(NSString *)alias
+           hostName:(NSString *)hostName
+            sshPort:(NSString *)sshPort
+               user:(NSString *)user
+        passwordRef:(NSString *)passwordRef
+            hostKey:(NSString *)hostKey
+         moshServer:(NSString *)moshServer
+      moshPortRange:(NSString *)moshPortRange
+         startUpCmd:(NSString *)startUpCmd
+         prediction:(enum BKMoshPrediction)prediction
+           proxyCmd:(NSString *)proxyCmd
+          proxyJump:(NSString *)proxyJump
+sshConfigAttachment:(NSString *)sshConfigAttachment
+      fpDomainsJSON:(NSString *)fpDomainsJSON;
+
 @end

--- a/BlinkConfig/BKSSHHost.swift
+++ b/BlinkConfig/BKSSHHost.swift
@@ -1,0 +1,191 @@
+//////////////////////////////////////////////////////////////////////////////////
+//
+// B L I N K
+//
+// Copyright (C) 2016-2019 Blink Mobile Shell Project
+//
+// This file is part of Blink.
+//
+// Blink is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Blink is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Blink. If not, see <http://www.gnu.org/licenses/>.
+//
+// In addition, Blink is also subject to certain additional terms under
+// GNU GPL version 3 section 7.
+//
+// You should have received a copy of these additional terms immediately
+// following the terms and conditions of the GNU General Public License
+// which accompanied the Blink Source Code. If not, see
+// <http://www.github.com/blinksh/blink>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+import Foundation
+
+import SSH
+
+
+public struct BKSSHHost {
+  private let content: [String:Any]
+
+  public var hostName: String?
+  public var identityFile: [String]?
+  public var password: String?
+  public var user: String?
+  public var port: String?
+  public var proxyCommand: String?
+  public var proxyJump: String?
+  public var compression: Bool?
+  public var compressionLevel: Int?
+  public var connectionTimeout: Int?
+  public var logLevel: SSHLogLevel?
+  public var controlMaster: ControlMasterOption?
+  public var forwardAgent: Bool?
+  public var sendEnv: [String]?
+  // TODO SendEnv, Tunnels, etc...
+  
+  public struct ValidationError: Error {
+    let message: String
+    public var description: String { message }
+  }
+  
+  public init(content: [String: Any]) throws {
+    self.content = content
+    
+    func castValue<T: SSHValue>(_ value: Any) throws -> T {
+      // Values must be mapped to a String
+      let value = value as! String
+      return try T(castSSHValue: value)
+    }
+    
+    func castList<T: SSHValue>(_ value: Any) throws -> [T] {
+      if let list = value as? [String] {
+        return try list.map { try T(castSSHValue: $0) }
+      } else {
+        return try (value as! String)
+          .split(separator: " ")
+          .map { try T(castSSHValue: String($0)) }
+      }
+    }
+    
+    for (key, value) in content {
+      do {
+        let key = key.lowercased()
+        
+        switch key {
+        case "hostname":            self.hostName           = try castValue(value)
+        case "password":            self.password           = try castValue(value)
+        case "user":                self.user               = try castValue(value)
+        case "port":                self.port               = try castValue(value)
+        case "proxycommand":        self.proxyCommand       = try castValue(value)
+        case "proxyjump":           self.proxyJump          = try castValue(value)
+        case "compression":         self.compression        = try castValue(value)
+        case "compressionlevel":    self.compressionLevel   = try castValue(value)
+        case "connectiontimeout":   self.connectionTimeout  = try castValue(value)
+        case "loglevel":            self.logLevel           = try castValue(value)
+        case "controlmaster":       self.controlMaster      = try castValue(value)
+        case "forwardagent":        self.forwardAgent       = try castValue(value)
+        case "sendenv":             self.sendEnv            = try castList(value)
+        case "identityfile":        self.identityFile       = try castList(value)
+        default:
+          // Skip unknown
+          break
+        }
+      } catch let error as ValidationError {
+        throw ValidationError(message: "\(key) \(value) - \(error.message)")
+      }
+    }
+  }
+
+  public func merge(_ host: BKSSHHost) throws -> BKSSHHost {
+    var configDict = content
+    configDict.mergeWithSSHConfigRules(host.content)
+    return try BKSSHHost(content: configDict)
+  }
+
+  public func sshClientConfig(authMethods: [SSH.AuthMethod]?,
+                              verifyHostCallback: SSHClientConfig.RequestVerifyHostCallback? = nil,
+                              agent: SSHAgent? = nil,
+                              logger: SSHLogPublisher? = nil) -> SSHClientConfig {
+    SSHClientConfig(
+      user: user ?? "root",
+      port: port,
+      proxyJump: proxyJump,
+      proxyCommand: proxyCommand,
+      authMethods: authMethods,
+      agent: agent,
+      loggingVerbosity: logLevel,
+      verifyHostCallback: verifyHostCallback,
+      connectionTimeout: connectionTimeout,
+      logger: logger,
+      compression: compression,
+      compressionLevel: compressionLevel
+    )
+  }
+}
+
+fileprivate protocol SSHValue {
+  init(castSSHValue val: String) throws
+}
+
+extension Bool: SSHValue {
+  fileprivate init(castSSHValue val: String) throws {
+    switch val.lowercased() {
+    case "yes":
+      self.init(true)
+    case "no":
+      self.init(false)
+    default:
+      throw BKSSHHost.ValidationError(message: "Value must be yes/no")
+    }
+  }
+}
+
+extension Int: SSHValue {
+  fileprivate init(castSSHValue val: String) throws {
+    guard let _ = Int(val) else {
+      throw BKSSHHost.ValidationError(message: "Value must be a number")
+    }
+    self.init(val)!
+  }
+}
+
+extension String: SSHValue {
+  fileprivate init(castSSHValue val: String) throws {
+    self.init(val)
+  }
+}
+
+extension SSHLogLevel: SSHValue {
+  fileprivate init(castSSHValue val: String) throws {
+    guard let _ = SSHLogLevel(val) else {
+      throw BKSSHHost.ValidationError(message: "Value must be QUIET, etc...")
+    }
+    self.init(val)!
+  }
+}
+
+public enum ControlMasterOption: String, SSHValue {
+  case auto     = "auto"
+  case ask      = "ask"
+  case autoask  = "autoask"
+  case yes      = "yes"
+  case no       = "no"
+  
+  fileprivate init(castSSHValue val: String) throws {
+    guard let _ = ControlMasterOption(rawValue: val) else {
+      throw BKSSHHost.ValidationError(message: "Value must be auto, ask, autoask, yes or no")
+    }
+    self.init(rawValue: val)!
+  }
+}

--- a/BlinkConfig/BlinkPaths.h
+++ b/BlinkConfig/BlinkPaths.h
@@ -46,6 +46,7 @@
 
 + (NSURL *) blinkURL;
 + (NSURL *) blinkSSHConfigFileURL;
++ (NSURL *) blinkGlobalSSHConfigFileURL;
 + (NSURL *) blinkKBConfigURL;
 
 + (NSString *) blinkKeysFile;

--- a/BlinkConfig/BlinkPaths.m
+++ b/BlinkConfig/BlinkPaths.m
@@ -150,6 +150,11 @@ NSString *__iCloudsDriveDocumentsPath = nil;
   return [[self blink] stringByAppendingPathComponent:@"hosts"];
 }
 
++ (NSURL *)blinkGlobalSSHConfigFileURL
+{
+  return [[self blinkURL] URLByAppendingPathComponent:@"ssh_global"];
+}
+
 + (NSURL *)blinkSSHConfigFileURL
 {
   return [[self blinkURL] URLByAppendingPathComponent:@"ssh_config"];

--- a/BlinkConfigTests/BlinkConfigTests.swift
+++ b/BlinkConfigTests/BlinkConfigTests.swift
@@ -1,0 +1,115 @@
+//////////////////////////////////////////////////////////////////////////////////
+//
+// B L I N K
+//
+// Copyright (C) 2016-2019 Blink Mobile Shell Project
+//
+// This file is part of Blink.
+//
+// Blink is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Blink is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Blink. If not, see <http://www.gnu.org/licenses/>.
+//
+// In addition, Blink is also subject to certain additional terms under
+// GNU GPL version 3 section 7.
+//
+// You should have received a copy of these additional terms immediately
+// following the terms and conditions of the GNU General Public License
+// which accompanied the Blink Source Code. If not, see
+// <http://www.github.com/blinksh/blink>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+import XCTest
+
+@testable import BlinkConfig
+
+class BlinkConfigTests: XCTestCase {
+  let fm = FileManager.default
+  let hostAlias = "test"
+  override func setUpWithError() throws {
+    BKHosts.loadHosts()
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    let sshConfigAttachment =
+"""
+Compression yes
+CompressionLevel 8
+ControlMaster no
+"""
+    
+    let _ = BKHosts.saveHost(hostAlias,
+                                withNewHost: hostAlias,
+                                hostName: "localhost",
+                                sshPort: "22",
+                                user: "glenda",
+                                password: "password",
+                                hostKey: "id_rsa",
+                                moshServer: "",
+                                moshPortRange: "",
+                                startUpCmd: "",
+                                prediction: BKMoshPrediction(rawValue: 0),
+                                proxyCmd: "exec nc %h:%p",
+                                proxyJump: "jumphost",
+                                sshConfigAttachment: sshConfigAttachment,
+                                fpDomainsJSON: "")
+  }
+  
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    try fm.removeItem(at: URL(fileURLWithPath: BlinkPaths.blinkHostsFile()))
+    try fm.removeItem(at: BlinkPaths.blinkSSHConfigFileURL())
+  }
+  
+func testBKHostsToSSHConfig() throws {
+  let hostString = try BKHosts.sshConfig().string()
+  let expectConfig = ["Host \(hostAlias)",
+                      "User glenda",
+                      "Port 22",
+                      "HostName localhost",
+                      "ProxyCommand exec nc %h:%p",
+                      "ProxyJump jumphost",
+                      "Compression yes",
+                      "ControlMaster no",
+                      "IdentityFile id_rsa"
+  ]
+
+  expectConfig.forEach { row in
+    if !hostString.contains(row) {
+      XCTFail("\(row) not found on hostString")
+    }
+  }
+  
+  // Password should be skipped
+  XCTAssertFalse(hostString.contains("Password password"))
+}
+  
+  func testSSHConfigToSSHClientConfig() throws {
+    // Test conversion to BKSSHHost.
+    // TODO First issue is that this BKSSHHost is of an "undefined" format, what
+    // makes it difficult to match to the one coming from SSHConfig as [String:Any].
+    // TODO One issue for example is the "other commands" on SSHCommand.
+    // A yes/no, will not get translated to true false sequence.
+    let baseHost = try BKSSHHost(content: ["user": "no-password",
+                                           "port": "2222",
+                                           "compression": "no",
+                                           "sendenv": "TERM LC*"])
+
+    let _ = try BKConfig().bkSSHHost(hostAlias, extending: baseHost)
+    guard let env = baseHost.sendEnv else {
+      XCTFail("No env received")
+      return
+    }
+    XCTAssert(env.contains("TERM") &&
+              env.contains("LC*"), "List mapping failed")
+  }
+}

--- a/SSH/SSHClientConfig.swift
+++ b/SSH/SSHClientConfig.swift
@@ -1,0 +1,188 @@
+//////////////////////////////////////////////////////////////////////////////////
+//
+// B L I N K
+//
+// Copyright (C) 2016-2019 Blink Mobile Shell Project
+//
+// This file is part of Blink.
+//
+// Blink is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Blink is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Blink. If not, see <http://www.gnu.org/licenses/>.
+//
+// In addition, Blink is also subject to certain additional terms under
+// GNU GPL version 3 section 7.
+//
+// You should have received a copy of these additional terms immediately
+// following the terms and conditions of the GNU General Public License
+// which accompanied the Blink Source Code. If not, see
+// <http://www.github.com/blinksh/blink>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import Combine
+import Foundation
+
+import LibSSH
+
+
+// TODO: check libssh api for string values
+extension ssh_options_e {
+  var name: String {
+    switch self {
+    case SSH_OPTIONS_HOST:              return "SSH_OPTIONS_HOST"
+    case SSH_OPTIONS_USER:              return "SSH_OPTIONS_USER"
+    case SSH_OPTIONS_LOG_VERBOSITY:     return "SSH_OPTIONS_LOG_VERBOSITY"
+    case SSH_OPTIONS_COMPRESSION_C_S:   return "SSH_OPTIONS_COMPRESSION_C_S"
+    case SSH_OPTIONS_COMPRESSION_S_C:   return "SSH_OPTIONS_COMPRESSION_S_C"
+    case SSH_OPTIONS_COMPRESSION:       return "SSH_OPTIONS_COMPRESSION"
+    case SSH_OPTIONS_COMPRESSION_LEVEL: return "SSH_OPTIONS_COMPRESSION_LEVEL"
+    case SSH_OPTIONS_PORT_STR:          return "SSH_OPTIONS_PORT_STR"
+    case SSH_OPTIONS_PROXYJUMP:         return "SSH_OPTIONS_PROXYJUMP"
+    case SSH_OPTIONS_PROXYCOMMAND:      return "SSH_OPTIONS_PROXYCOMMAND"
+    case SSH_OPTIONS_SSH_DIR:           return "SSH_OPTIONS_SSH_DIR"
+    default:                            return "raw: \(rawValue)"
+    }
+  }
+}
+
+/**
+ Delegates the responsability of interpreting a "Yes"/"Si"/"да" to the app.
+ Should return a `.affirmative` if it's a positive answer.
+ */
+public enum InteractiveResponse {
+  /// "Yes"/"Si"/"да"
+  case affirmative
+  /// "No"/"No"/"нет"
+  case negative
+}
+
+/**
+ Delegates the responsability of implementing and handling the cases.
+ */
+public enum VerifyHost {
+  case changed(serverFingerprint: String)
+  case unknown(serverFingerprint: String)
+  case notFound(serverFingerprint: String)
+}
+
+// TODO Having the middle-man here to parse the config will allow us to then
+// use the same defaults, etc... as with the SSHClientConfig, so we can abstract,
+// modify, and adapt to our use cases.
+
+public struct SSHClientConfig: CustomStringConvertible, Equatable {
+  let user: String
+  let port: String
+  
+  // TODO We could pass a callbacks type on dial instead of here.
+  public typealias RequestVerifyHostCallback = (VerifyHost) -> AnyPublisher<InteractiveResponse, Error>
+  
+  /**
+   List of all of the authentication methods to use. Priority in which they are tried is not tied to their position on the list, defined in `SSHClient.validAuthMethods()`.
+   1. Publickey
+   2. Password
+   3. Keyboard Interactive
+   4. Hostbased
+   */
+  var authenticators: [Authenticator] = []
+  var agent: SSHAgent?
+
+  /// `.ssh` path location
+  let sshDirectory: String?
+  /// Path to config file
+  let sshClientConfigPath: String?
+  /// If `nil` no host verification will be done
+  let requestVerifyHostCallback: RequestVerifyHostCallback?
+  
+  let logger: SSHLogPublisher?
+  /// Default verbosity logging is disabled, SSH_LOG_NOLOG
+  let loggingVerbosity: SSHLogLevel
+  
+  let keepAliveInterval: Int? = nil
+  
+  let proxyCommand: String?
+  let proxyJump: String?
+  
+  let connectionTimeout: Int
+  
+  let compression: Bool
+  let compressionLevel: Int
+  
+  // TODO We can still offer this as a way to show what went through and simplify.
+  // We may have enough with the one coming from the new BKConfig.
+  public var description: String { """
+  user: \(user)
+  port: \(port)
+  authenticators: \(authenticators.map { $0.displayName }.joined(separator: ", "))
+  proxyJump: \(proxyJump)
+  proxyCommand: \(proxyCommand)
+  compression: \(compression)
+  compressionLevel: \(compressionLevel)
+  """}
+
+  /**
+   - Parameters:
+   - user:
+   - port: Default will be `22`
+   - authMethods: Different authentication methods to try
+   - loggingVerbosity: Default LibSSH logging shown is `SSH_LOG_NOLOG`
+   - verifyHostCallback:
+   - terminalEmulator:
+   - sshDirectory: `ssh` directory, if `nil` it will use the default directory
+   - keepAliveInterval: if `nil` it won't send KeepAlive packages from Client to the Server
+   */
+  public init(user: String,
+              port: String? = nil,
+              proxyJump: String? = nil,
+              proxyCommand: String? = nil,
+              authMethods: [AuthMethod]? = nil,
+              agent: SSHAgent? = nil,
+              loggingVerbosity: SSHLogLevel? = nil,
+              verifyHostCallback: RequestVerifyHostCallback? = nil,
+              connectionTimeout: Int? = nil,
+              sshDirectory: String? = nil,
+              sshClientConfigPath: String? = nil,
+              logger: SSHLogPublisher? = nil,
+              keepAliveInterval: Int? = nil,
+              compression: Bool? = nil,
+              compressionLevel: Int? = nil) {
+    // We do our own constructor because the automatic one cannot define optional params.
+    self.user = user
+    self.port = port ?? "22"
+    self.proxyCommand = proxyCommand
+    self.proxyJump = proxyJump
+    self.agent = agent
+    self.loggingVerbosity = loggingVerbosity ?? .none
+    self.requestVerifyHostCallback = verifyHostCallback
+    self.sshDirectory = sshDirectory
+    self.sshClientConfigPath = sshClientConfigPath
+    self.logger = logger
+    self.connectionTimeout = connectionTimeout ?? 30
+    self.compression = compression ?? false
+    self.compressionLevel = compressionLevel ?? 6
+    
+    // TODO Disable Keep Alive for now. LibSSH is not processing correctly the messages
+    // that may come back from the server.
+    // self.keepAliveInterval = keepAliveInterval
+    
+    authMethods?.forEach({ auth in
+      if let auth = (auth as? Authenticator) {
+        self.authenticators.append(auth)
+      }
+    })
+  }
+  
+  public static func == (lhs: SSHClientConfig, rhs: SSHClientConfig) -> Bool {
+    return (lhs.port == rhs.port &&
+      lhs.user == rhs.user)
+  }
+}

--- a/Settings/Model/BKDefaults.h
+++ b/Settings/Model/BKDefaults.h
@@ -31,6 +31,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import <BlinkConfig/BlinkConfig-Swift.h>
+
+
 extern NSString *const BKAppearanceChanged;
 
 typedef NS_ENUM(NSInteger, BKLayoutMode) {
@@ -60,6 +63,7 @@ typedef NS_ENUM(NSInteger, BKKeyboardStyle) {
 @property (nonatomic, strong) NSNumber *fontSize;
 @property (nonatomic, strong) NSNumber *externalDisplayFontSize;
 @property (nonatomic, strong) NSString *defaultUser;
+@property (nonatomic, strong) BKGlobalSSHConfig *globalSSHConfig;
 @property (nonatomic) BOOL cursorBlink;
 @property (nonatomic) NSUInteger enableBold;
 @property (nonatomic) BOOL boldAsBright;
@@ -109,6 +113,7 @@ typedef NS_ENUM(NSInteger, BKKeyboardStyle) {
 + (NSString *)xCallBackURLKey;
 + (BOOL)disableCustomKeyboards;
 + (void)setDefaultUserName:(NSString*)name;
++ (void)saveGlobalSSHConfig;
 + (NSString*)defaultUserName;
 + (BKLayoutMode)layoutMode;
 + (BKOverscanCompensation)overscanCompensation;

--- a/Settings/Model/BKDefaults.m
+++ b/Settings/Model/BKDefaults.m
@@ -35,7 +35,7 @@
 #import "UIDevice+DeviceName.h"
 #import "BlinkPaths.h"
 #import "LayoutManager.h"
-#import <BlinkConfig/BlinkConfig-Swift.h>
+
 
 BKDefaults *defaults;
 
@@ -60,6 +60,7 @@ NSString *const BKAppearanceChanged = @"BKAppearanceChanged";
   _fontSize = [coder decodeObjectOfClasses:numbers forKey:@"fontSize"];
   _externalDisplayFontSize = [coder decodeObjectOfClasses:numbers forKey:@"externalDisplayFontSize"];
   _defaultUser = [coder decodeObjectOfClasses:strings forKey:@"defaultUser"];
+  _globalSSHConfig = [coder decodeObjectOfClasses: [NSSet setWithObjects: [BKGlobalSSHConfig class], nil] forKey:@"globalSSHConfig"];
   _cursorBlink = [coder decodeBoolForKey:@"cursorBlink"];
   _enableBold = [coder decodeIntegerForKey:@"enableBold"];
   _boldAsBright = [coder decodeBoolForKey:@"boldAsBright"];
@@ -87,6 +88,7 @@ NSString *const BKAppearanceChanged = @"BKAppearanceChanged";
   [encoder encodeObject:_fontSize forKey:@"fontSize"];
   [encoder encodeObject:_externalDisplayFontSize forKey:@"externalDisplayFontSize"];
   [encoder encodeObject:_defaultUser forKey:@"defaultUser"];
+  [encoder encodeObject:_globalSSHConfig forKey:@"globalSSHConfig"];
   [encoder encodeBool:_cursorBlink forKey:@"cursorBlink"];
   [encoder encodeInteger:_enableBold forKey:@"enableBold"];
   [encoder encodeBool:_boldAsBright forKey:@"boldAsBright"];
@@ -187,6 +189,10 @@ NSString *const BKAppearanceChanged = @"BKAppearanceChanged";
   if(!defaults.defaultUser || ![[defaults.defaultUser stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] length]){
     [defaults setDefaultUser:[UIDevice getInfoTypeFromDeviceName:BKDeviceInfoTypeUserName]];
   }
+
+  if(!defaults.globalSSHConfig) {
+    [BKDefaults saveGlobalSSHConfig];
+  }
 }
 
 + (void)setCursorBlink:(BOOL)state
@@ -236,6 +242,12 @@ NSString *const BKAppearanceChanged = @"BKAppearanceChanged";
 + (void)setDefaultUserName:(NSString*)name
 {
   defaults.defaultUser = name;
+}
+
++ (void)saveGlobalSSHConfig
+{
+  BKGlobalSSHConfig *config = [[BKGlobalSSHConfig alloc] initWithUser: defaults.defaultUser];
+  [config saveFile];
 }
 
 + (void)setLayoutMode:(BKLayoutMode)mode {


### PR DESCRIPTION
- Using ssh config as the central piece to obtain configurations.
- BKConfig is an intermediary between Blink configurations and the SSH
information.
- Use the BKSSHHost from BKConfig to generate the proper SSHClientConfiguration
and centralize all the knowledge and transformations there.
- Refactored SSHClient configuration to a separate file. Initially I thought we
would do the transformation there, but now it is just convenient.