### PR TITLE
Fix hardware keyboard detection in Shortcuts Bar setup

### DIFF
--- a/Blink/KBTracker.swift
+++ b/Blink/KBTracker.swift
@@ -93,6 +93,8 @@ class KBObserver: NSObject, UIInteraction {
       return
     }
      
+    KBTracker.shared.detectHardwareKBWithSoftwareKBHeight(height: kbEndFrame.height)
+
     self.kbScreenFrame = kbEndFrame
     self.view?.setNeedsLayout()
     NotificationCenter.default.post(name: NSNotification.Name(rawValue: LayoutManagerBottomInsetDidUpdate), object: nil)
@@ -110,12 +112,16 @@ class KBObserver: NSObject, UIInteraction {
       return
     }
      
+    KBTracker.shared.detectHardwareKBWithSoftwareKBHeight(height: kbEndFrame.height)
+
     self.kbScreenFrame = kbEndFrame
     self.view?.setNeedsLayout()
     NotificationCenter.default.post(name: NSNotification.Name(rawValue: LayoutManagerBottomInsetDidUpdate), object: nil)
   }
 
   @objc private func _keyboardWillChangeFrame(notification: Notification) {
+    // keyboardWillChangeFrameNotification always comes with a corresponding keyboardWillShowNotification or keyboardWillHideNotification.
+    // Code moved to the more explicit show and hide notifications.
     return
     guard
       let screen = notification.object as? UIScreen,


### PR DESCRIPTION
- Update isHardwareKB in KBTracker when keyboard state changes.
- Stop overriding inputAssistantItem, which is advised against in UIKit's documentation.
- Add comment on why _keyboardWillChangeFrame is disabled.

In https://github.com/blinksh/blink/commit/9e5e024c07a93d163099ee433cf9c81a130dec30, `_keyboardWillChangeFrame` is disabled with an early return, therefore detectHardwareKBWithSoftwareKBHeight is not called to update keyboard state.