### PR TITLE
Assert session args is valid UTF-8

### DIFF
--- a/Sessions/Session.m
+++ b/Sessions/Session.m
@@ -159,6 +159,7 @@ void *run_session(void *sessionData)
 }
 
 - (void)_run {
+  assert(_args.UTF8String != NULL);
   int argc = makeargs(_args.UTF8String, &_argv);
   [self main:argc argv:_argv];
 }


### PR DESCRIPTION
If it is NULL, null pointer dereferencing in makeargs() would result in undefined behavior. https://developer.apple.com/documentation/xcode/null-reference-creation-and-null-pointer-dereference