### PR TITLE
Update network_ios to v0.3

### DIFF
--- a/Resources/commandDictionary.plist
+++ b/Resources/commandDictionary.plist
@@ -247,6 +247,13 @@
 		<string>AaB:b:Cc:DdfG:g:h:I:i:k:K:Ll:M:m:noP:p:QqRrS:s:T:t:vW:z:</string>
 		<string>no</string>
 	</array>
+	<key>ping6</key>
+	<array>
+		<string>network_ios.framework/network_ios</string>
+		<string>ping6_main</string>
+		<string>DdfHnNoqrRtvwWa:b:c:g:h:I:i:l:p:S:s:z:k:K:</string>
+		<string>no</string>
+	</array>
 	<key>printenv</key>
 	<array>
 		<string>shell.framework/shell</string>
@@ -464,12 +471,12 @@
 		<string>0E:I:J:L:n:oP:pR:s:tx</string>
 		<string>no</string>
 	</array>
-  <key>wol</key>
-  <array>
-    <string>network_ios.framework/network_ios</string>
-    <string>_Z8wol_mainiPKPc</string>
-    <string>hqb:p:d:</string>
-    <string>no</string>
-  </array>
+	<key>wol</key>
+	<array>
+		<string>network_ios.framework/network_ios</string>
+		<string>_Z8wol_mainiPKPc</string>
+		<string>hqb:p:d:</string>
+		<string>no</string>
+	</array>
 </dict>
 </plist>

--- a/xcfs/Package.swift
+++ b/xcfs/Package.swift
@@ -69,8 +69,8 @@ var binaryTargets: [PackageDescription.Target] = [
   ),
   (
     "network_ios",
-    "18e96112ae86ec39390487d850e7732d88e446f9f233b2792d633933d4606d46",
-    "https://github.com/holzschu/network_ios/releases/download/v0.2/network_ios.xcframework.zip"
+    "9fe5f119b2d5568d2255e2540f36e76525bfbeaeda58f32f02592ca8d74f4178",
+    "https://github.com/holzschu/network_ios/releases/download/v0.3/network_ios.xcframework.zip"
   )
 ].map { name, checksum, url in PackageDescription.Target.binaryTarget(name: name, url: url, checksum: checksum)}
 


### PR DESCRIPTION
Tested on iPad (10th gen) with a custom build. `ifconfig` and `ping6` works as intended.

Closes #1984

### Miscellaneous

- `commandDictionary.plist` was auto-formatted on save by Xcode.
- Binaries provided by upstream are built with Xcode 14.2.