### PR TITLE
Bypass paywall in Developer builds to unblock local self-builds

### DIFF
--- a/Blink/Subscriptions/EntitlementsManager.swift
+++ b/Blink/Subscriptions/EntitlementsManager.swift
@@ -165,6 +165,11 @@ public class EntitlementsManager: ObservableObject, EntitlementsSourceDelegate {
   }
 
   public func hasActiveSubscriptions() -> Bool {
+    // Allow developer/TestFlight builds to bypass the paywall so
+    // self-built installs can proceed without RevenueCat configuration.
+    if FeatureFlags.noSubscriptionNag {
+      return true
+    }
     print(currentPlanName())
     return customerTier() != CustomerTier.Free
   }

--- a/Blink/Subscriptions/EntitlementsManager.swift
+++ b/Blink/Subscriptions/EntitlementsManager.swift
@@ -165,13 +165,12 @@ public class EntitlementsManager: ObservableObject, EntitlementsSourceDelegate {
   }
 
   public func hasActiveSubscriptions() -> Bool {
-    // Allow developer/TestFlight builds to bypass the paywall so
-    // self-built installs can proceed without RevenueCat configuration.
-    if FeatureFlags.noSubscriptionNag {
-      return true
-    }
+    #if BLINK_PUBLISHING_OPTION_DEVELOPER
+    return true
+    #else
     print(currentPlanName())
     return customerTier() != CustomerTier.Free
+    #endif
   }
   
   public func groupsCheckViolation() -> Bool {


### PR DESCRIPTION
## Summary

Developer builds currently show the paywall even when RevenueCat isn’t configured, which blocks local testing.
This change lets Developer builds proceed without subscriptions; App Store behavior is unchanged.

## What changed

`EntitlementsManager.hasActiveSubscriptions()`: return true in debug.

## Behavior by build type

- Developer (Debug): Paywall skipped so self-builds can launch and test.
- TestFlight/App Store: Unchanged; paywall logic remains intact.

## Testing

Debug build launches without the subscription screen.
Switching compilation condition to BLINK_PUBLISHING_OPTION_APPSTORE still shows the paywall as before.

## Risk/Considerations

Keep this bypass limited to Developer builds (not TestFlight) to avoid altering tester flows. If preferred, I can update the guard accordingly.