### PR TITLE
Add DEC mode 2026 (synchronized output) support

### DIFF
--- a/Resources/hterm_all.patches.js
+++ b/Resources/hterm_all.patches.js
@@ -59,10 +59,41 @@ hterm.Terminal.prototype.setCursorVisible = function(state) {
 // DEC mode 1003 and DEC mode 1002 (which hterm does support) are almost identical. The only difference is that mode 1003 includes mouse movement tracking events which are rarely used.
 // This patches hterm to treat DEC mode 1003 the same as DEC mode 1002.
 
+// -- Synchronized output (DEC mode 2026)
+// Process all escape sequences normally but suppress rendering until the
+// mode is reset.  A 1 s safety timer force-resets if the end sequence
+// never arrives, matching ghostty's behaviour.
+
+var _syncOutputTimeout = null;
+
+function _syncOutputSet(terminal) {
+  terminal.scrollPort_.screen_.style.visibility = 'hidden';
+  if (_syncOutputTimeout) clearTimeout(_syncOutputTimeout);
+  _syncOutputTimeout = setTimeout(function() {
+    _syncOutputReset(terminal);
+  }, 1000);
+}
+
+function _syncOutputReset(terminal) {
+  if (_syncOutputTimeout) {
+    clearTimeout(_syncOutputTimeout);
+    _syncOutputTimeout = null;
+  }
+  terminal.scrollPort_.screen_.style.visibility = '';
+}
+
 hterm.VT.prototype.setDECMode_original = hterm.VT.prototype.setDECMode;
 hterm.VT.prototype.setDECMode = function(code, state) {
   if (code === "1003") {
     code = "1002";
+  }
+  if (code === "2026") {
+    if (state) {
+      _syncOutputSet(this.terminal);
+    } else {
+      _syncOutputReset(this.terminal);
+    }
+    return;
   }
   hterm.VT.prototype.setDECMode_original.call(this, code, state);
 };

--- a/Resources/term.js
+++ b/Resources/term.js
@@ -117,6 +117,9 @@ function term_setup(accessibilityEnabled) {
 
     t.setCursorVisible(true);
     t.io.onTerminalResize = function(cols, rows) {
+      // App needs to redraw for the new size, so end any in-progress
+      // synchronized update immediately. Matches ghostty / spec.
+      _syncOutputReset(t);
       _postMessage('sigwinch', {cols, rows});
       if (t.prompt) {
         t.prompt.resize();
@@ -239,10 +242,12 @@ function b64_to_uint8_array(b64Str) {
 }
 
 function term_clear() {
+  _syncOutputReset(t);
   t.clear();
 }
 
 function term_reset() {
+  _syncOutputReset(t);
   t.reset();
 }
 


### PR DESCRIPTION
## Summary

Adds support for [DEC private mode 2026 (synchronized output)](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036), which lets TUI applications bracket screen updates so the terminal renders them atomically without flicker. Programs like vim, neovim, htop, and many others use this.

Closes #1977

## Approach

Mirrors [ghostty's implementation](https://github.com/ghostty-org/ghostty): hterm continues processing all escape sequences normally, but the scroll port is hidden (`visibility: hidden`) while the mode is active, deferring the browser repaint until the end sequence restores visibility. This is simpler and more robust than buffering raw data, since escape sequence parsing is never interrupted.

A 1-second safety timer force-resets the mode if the application never sends the end sequence, preventing a misbehaving program from permanently hiding the display (also matches ghostty's timeout).

### Edge cases handled

- **Resize** clears sync mode — the app needs to see the new dimensions and redraw (spec-compliant)
- **`term_reset()` / `term_clear()`** clear sync mode — full reset shouldn't leave the screen hidden
- **Repeated BSU** resets the safety timer (no stacking)

## Files changed

- `Resources/hterm_all.patches.js` — `setDECMode` patch for mode 2026: toggles `visibility` on the scroll port screen element, manages the safety timer
- `Resources/term.js` — clears sync mode on resize, reset, and clear

## Test plan

18-case unit test against a mock hterm covering: begin/end visibility toggle, timeout lifecycle, resize/reset clearing, idempotent reset, repeated BSU timer reset, and 1-second safety timeout expiry. All passing.