### PR TITLE
Fix trailing EOL whitespace when copying terminal selection

### DIFF
--- a/Resources/term.js
+++ b/Resources/term.js
@@ -36,8 +36,9 @@ hterm.Terminal.prototype.copyStringToClipboard = function(content) {
     setTimeout(this.showOverlay.bind(this, hterm.notifyCopyMessage, 500), 200);
   }
 
+  const normalizedContent = term_normalizeSelectionForClipboard(content);
   document.getSelection().removeAllRanges();
-  _postMessage('copy', {content});
+  _postMessage('copy', {content: normalizedContent});
 };
 
 document.addEventListener('selectionchange', function() {
@@ -369,6 +370,19 @@ function term_loadFontFromCss(url, name) {
   term_setFontFamily(name);
 }
 
+function term_normalizeSelectionForClipboard(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return '';
+  }
+
+  // hterm selection may include row-padding spaces at EOL; those should not leak
+  // into the system clipboard as trailing whitespace.
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/[ \t]+$/g, '');
+}
+
 function term_getCurrentSelection() {
   const selection = document.getSelection();
     if (!selection || selection.rangeCount === 0 || selection.type === 'Caret') {
@@ -382,7 +396,7 @@ function term_getCurrentSelection() {
   return {
     base: selection.baseNode.textContent,
     offset: selection.baseOffset,
-    text: t.getSelectionText() || "",
+    text: term_normalizeSelectionForClipboard(t.getSelectionText() || ""),
     rect,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #2133 by normalizing terminal selection text before it is sent to the clipboard.

When copying from Blink, trailing row-padding whitespace at end-of-line is now removed, so pasting into Safari/other apps no longer introduces random trailing spaces.

## Root Cause

Blink forwarded `hterm` selection text directly to native clipboard handling.  
`hterm` selection can include visual row-padding spaces at EOL, so those spaces leaked into pasted text.

## What Changed

In `/Users/jiefeng/git/blink/Resources/term.js`:

- Added `term_normalizeSelectionForClipboard(text)` to:
  - normalize `\r\n` to `\n`
  - strip trailing spaces/tabs before newline
  - strip trailing spaces/tabs at end of selection
- Updated `copyStringToClipboard` to send normalized content.
- Updated `term_getCurrentSelection()` to return normalized `text` for consistency with native menu actions.

## Validation

- JS syntax check passed: `node --check /Users/jiefeng/git/blink/Resources/term.js`
- Sanity checks confirmed:
  - internal whitespace remains unchanged
  - EOL trailing whitespace is removed
  - final trailing whitespace is removed

## Notes

I could not run full Xcode build/test in this environment due package resolution/toolchain issues unrelated to this patch.
