### PR TITLE
Fix font persistence in Lockdown mode

### DIFF
--- a/Blink/TermView.m
+++ b/Blink/TermView.m
@@ -825,8 +825,10 @@ struct winsize __winSizeFromJSON(NSDictionary *json) {
 {
   NSMutableArray *script = [[NSMutableArray alloc] init];
   BOOL lockdownMode = [[NSUserDefaults.standardUserDefaults objectForKey:@"LDMGlobalEnabled"] boolValue];
-  BKFont *font = lockdownMode ? nil : [BKFont withName: params.fontName ?: [BLKDefaults selectedFontName]];
-  NSString *fontFamily = font.name;
+  BKFont *selectedFont = [BKFont withName: params.fontName ?: [BLKDefaults selectedFontName]];
+  // In Lockdown mode, keep bundled fonts but disable non-bundled ones.
+  BKFont *font = (lockdownMode && selectedFont.isCustom) ? nil : selectedFont;
+  NSString *fontFamily = font.name ?: (lockdownMode ? @"monospace" : nil);
   NSString *content = font.content;
   if (font && font.isCustom && content) {
     [script addObject:term_appendUserCss(content)];

--- a/Resources/term.js
+++ b/Resources/term.js
@@ -154,7 +154,6 @@ function term_init(accessibilityEnabled, lockdownMode) {
     //    document.body.style.backgroundColor = bgColor;
     //    document.body.parentNode.style.backgroundColor = bgColor;
     if (lockdownMode) {
-      term_set('font-family', 'monospace');
       term_setup(accessibilityEnabled);
     } else {
       waitForFontFamily(term_setup);


### PR DESCRIPTION
## Summary

Fix terminal font persistence in iOS Lockdown Mode.

Fixes #2137.

## Problem

When Lockdown Mode is enabled, changing the terminal font in Blink appears to work temporarily, but after opening a new tab or relaunching the app, the terminal always renders with generic `monospace` (Courier-like), ignoring the selected font.

## Root Cause

Two Lockdown-specific behaviors combined to override the user selection:

1. Native init script disabled all selected fonts in Lockdown by setting:
   `font = nil` whenever `lockdownMode == true`.
2. JS init then unconditionally forced:
   `term_set('font-family', 'monospace')`.

So even bundled fonts (safe, app-provided) were dropped and replaced on startup.

## What Changed

### `Blink/TermView.m`
- Load the selected font first.
- In Lockdown Mode, only block **non-bundled/custom** fonts (`isCustom`).
- Keep bundled fonts active.
- If blocked in Lockdown, explicitly fallback to `monospace`.

### `Resources/term.js`
- Remove unconditional Lockdown override:
  `term_set('font-family', 'monospace');`
- Keep existing `term_setup(accessibilityEnabled)` flow unchanged.

## Behavior After This PR

- Lockdown ON + bundled font selected:
  font persists across new tabs and app relaunch.
- Lockdown ON + non-bundled custom font selected:
  fallback to `monospace` (safety behavior preserved).
- Lockdown OFF:
  unchanged behavior.

## Testing

### Manual
- [x] Verified code path for Lockdown init and font application.
- [ ] Device test: Lockdown ON, switch between bundled fonts, open new tab, relaunch app.
- [ ] Device test: Lockdown ON, choose custom font, verify fallback to monospace.
- [ ] Regression check: Lockdown OFF font behavior remains unchanged.

### Automated
- [ ] Not run in this environment due existing SwiftPM manifest/toolchain resolution issue during `xcodebuild -list` (unrelated dependency manifest failure).

## Risk / Scope

Low and localized:
- Touches only terminal startup font selection logic under Lockdown mode.
- Does not change rendering pipeline outside startup conditions.
