### PR TITLE
Show status bar in Fit mode

### DIFF
--- a/Blink/BlinkMenu.m
+++ b/Blink/BlinkMenu.m
@@ -279,10 +279,7 @@ const CGFloat MENU_PADDING = 10.0;
             actionWithTitle:noTitle ? @"" : @"Fit"
             image:nil
             identifier:elementID handler:^(__kindof UIAction * _Nonnull action) {
-      [delegate.currentTerm unlockLayout];
-      delegate.currentTerm.sessionParams.layoutMode = BKLayoutModeSafeFit;
-      [self.superview setNeedsLayout];
-      
+      [delegate.currentTerm setLayoutModeWithLayoutMode:BKLayoutModeSafeFit];
     }
     ];
     action.state = delegate.currentTerm.sessionParams.layoutMode == BKLayoutModeSafeFit ? UIMenuElementStateOn : UIMenuElementStateOff;
@@ -293,9 +290,7 @@ const CGFloat MENU_PADDING = 10.0;
             actionWithTitle:noTitle ? @"" : @"Fill"
             image:nil
             identifier:elementID handler:^(__kindof UIAction * _Nonnull action) {
-      [delegate.currentTerm unlockLayout];
-      delegate.currentTerm.sessionParams.layoutMode = BKLayoutModeFill;
-      [self.superview setNeedsLayout];
+      [delegate.currentTerm setLayoutModeWithLayoutMode:BKLayoutModeFill];
     }
     ];
     action.state = delegate.currentTerm.sessionParams.layoutMode == BKLayoutModeFill ? UIMenuElementStateOn : UIMenuElementStateOff;
@@ -307,9 +302,7 @@ const CGFloat MENU_PADDING = 10.0;
             actionWithTitle:noTitle ? @"" : @"Cover"
             image:nil
             identifier:elementID handler:^(__kindof UIAction * _Nonnull action) {
-      [delegate.currentTerm unlockLayout];
-      delegate.currentTerm.sessionParams.layoutMode = BKLayoutModeCover;
-      [self.superview setNeedsLayout];
+      [delegate.currentTerm setLayoutModeWithLayoutMode:BKLayoutModeCover];
     }
     ];
     action.state = delegate.currentTerm.sessionParams.layoutMode == BKLayoutModeCover ? UIMenuElementStateOn : UIMenuElementStateOff;

--- a/Blink/SpaceController.swift
+++ b/Blink/SpaceController.swift
@@ -57,7 +57,15 @@ class SpaceController: UIViewController, LayoutInsetsProvider {
   var sceneRole: UISceneSession.Role = UISceneSession.Role.windowApplication
   
   private var _viewportsKeys = [UUID]()
-  private var _currentKey: UUID? = nil
+  private var _currentKey: UUID? = nil {
+    didSet {
+      guard _currentKey != oldValue else {
+        return
+      }
+
+      refreshSystemBarsAppearance()
+    }
+  }
   
   private var _hud: MBProgressHUD? = nil
   
@@ -188,6 +196,7 @@ class SpaceController: UIViewController, LayoutInsetsProvider {
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
+    refreshSystemBarsAppearance()
     
     #if targetEnvironment(macCatalyst)
     guard let appBundleUrl = Bundle.main.builtInPlugInsURL else {
@@ -266,6 +275,21 @@ class SpaceController: UIViewController, LayoutInsetsProvider {
     default:
       overrideUserInterfaceStyle = .unspecified
     }
+  }
+
+  private var _shouldShowSystemStatusBar: Bool {
+    guard view.window?.screen === UIScreen.main,
+          let term = currentTerm()
+    else {
+      return false
+    }
+
+    let layoutMode = BKLayoutMode(rawValue: term.sessionParams.layoutMode) ?? BLKDefaults.layoutMode()
+    return layoutMode == .safeFit
+  }
+
+  @objc func refreshSystemBarsAppearance() {
+    setNeedsStatusBarAppearanceUpdate()
   }
   
   public override func viewDidLoad() {
@@ -709,7 +733,7 @@ extension SpaceController: TermControlDelegate {
 // MARK: General tunning
 
 extension SpaceController {
-  public override var prefersStatusBarHidden: Bool { true }
+  public override var prefersStatusBarHidden: Bool { !_shouldShowSystemStatusBar }
   public override var prefersHomeIndicatorAutoHidden: Bool { true }
 }
 

--- a/Blink/TermController.swift
+++ b/Blink/TermController.swift
@@ -606,6 +606,8 @@ extension TermController: TermDeviceDelegate {
       self.unlockLayout()
     }
     self.view?.setNeedsLayout()
+
+    (layoutProvider as? SpaceController)?.refreshSystemBarsAppearance()
   }
 }
 


### PR DESCRIPTION
## Summary

- make status bar visibility follow the active terminal layout mode
- show it only for `Fit`
- keep existing fullscreen behavior for `Cover` and `Fill`

## Testing

- tested on iPhone XS Max running iOS 18.7.3
- `Fit` shows the status bar
- `Cover` and `Fill` keep it hidden
