### PR TITLE
Remove stale mosh1 hint from mosh's error message

### DIFF
--- a/Blink/Commands/mosh/mosh.swift
+++ b/Blink/Commands/mosh/mosh.swift
@@ -536,7 +536,6 @@ enum MoshError: Error, LocalizedError {
 
   func die(message: String) -> Int32 {
     print(message, to: &stderr)
-    print("Use mosh1 for the deprecated (previous) mosh version.", to: &stderr)
     return -1
   }
 


### PR DESCRIPTION
This PR is a tiny error-message fix:

> Use mosh1 for the deprecated (previous) mosh version.

`mosh1` has since been removed, so this points users at a command that no longer exists. Reported in #2254 and confirmed by @carloscabanero in the thread:

> Yep, the commands have been removed. I forgot to update the message and the release notes.

This drops that single line from `mosh`'s `die()`, so a failed connection no longer references the removed command. No other behavior changes.

Fixes #2254