### PR TITLE
Fix main-thread deadlock when creating a tab from the Quick Actions menu

### DIFF
--- a/Blink/SpaceController.swift
+++ b/Blink/SpaceController.swift
@@ -1269,8 +1269,16 @@ extension SpaceController: SnippetContext {
 // MARK: SceneIntent handlers
 extension SpaceController {
   @objc func runShellSessionIntent(command: String = "") {
-    DispatchQueue.main.sync {
-      self._newShellAction(command: command)
+    // Reached both from background-thread intent/URL handlers (which need main.sync) and
+    // from the Quick Actions menu's "Create" action, which already runs on the main
+    // thread — where main.sync reenters the current queue, deadlocks and crashes. Run
+    // directly when we're already on main.
+    if Thread.isMainThread {
+      _newShellAction(command: command)
+    } else {
+      DispatchQueue.main.sync {
+        self._newShellAction(command: command)
+      }
     }
   }
 


### PR DESCRIPTION
## What

The Quick Actions menu's **Create** action crashes the app.

`BlinkActionTabCreate` (`Blink/BlinkMenu.m`) calls `runShellSessionIntentWithCommand:`
on the main thread, but `runShellSessionIntent` (`Blink/SpaceController.swift`) always
hops to the main queue with `DispatchQueue.main.sync`. Calling `main.sync` from the main
thread reenters the queue it is already running on and deadlocks, so the app is
terminated. `Create` is the only Quick Actions item routed through this method, which is
why the others are unaffected.

## Fix

Run the work inline when already on the main thread; keep the `main.sync` hop for the
background-thread intent/URL callers, which still need it.

## Testing

- Quick Actions → **Create** now opens a new tab instead of crashing.
- The background intent/URL handler path is unchanged.

Fixes #2272
