### PR TITLE
fix: invisible IME composition text with custom themes

### DIFF
--- a/Resources/hterm_all.patches.js
+++ b/Resources/hterm_all.patches.js
@@ -66,3 +66,15 @@ hterm.VT.prototype.setDECMode = function(code, state) {
   }
   hterm.VT.prototype.setDECMode_original.call(this, code, state);
 };
+
+// Normalize custom theme colors before changing IME alpha.
+(function() {
+  var originalSetAlpha = lib.colors.setAlpha;
+  lib.colors.setAlpha = function(color, alpha) {
+    if (typeof color === 'string') {
+      var normalized = lib.colors.normalizeCSS(color);
+      if (normalized) color = normalized;
+    }
+    return originalSetAlpha.call(this, color, alpha);
+  };
+})();


### PR DESCRIPTION
Close #2268

## Purpose
When Blink uses a custom theme, such as `https://github.com/catppuccin/blink/blob/main/themes/catppuccin-mocha.js`, the IME cannot work normally while the custom theme is on.

## Why?

The IME composition caret calls `setAlpha()` with the theme cursor color. Some custom themes use hex or named CSS colors, while `setAlpha()` only accepts `rgb()` and `rgba()` values.
Color parsing therefore failed and interrupted caret positioning, leaving the pre-edit text off-screen.

1. [Theme](https://github.com/catppuccin/blink/blob/main/themes/catppuccin-mocha.js) set `t.prefs_.set('cursor-color', "#f2cdcd");`
2. Then `o.style.backgroundColor = lib.colors.setAlpha(t.getCursorColor(), 1);`
3. `color` only accept `rgb()`, `rgba()`
```javascript
B.colors.setAlpha = function(color, alpha) {
    var rgba = B.colors.crackRGB(color);
    rgba[3] = alpha;
    return B.colors.arrayToRGBA(rgba);
};
```
4. `setAlpha("#f2cdcd", 1)` → `var rgba = null;`, `rgba[3] = 1; // TypeError` → `_moveCaret()` won't be reached.
5. `this.caret.style.top = "-9999px"; this.caret.style.left = "-9999px";` → Cursor is still out of screen.

## AI Use Disclosure
AI suggests the fix. The position of the issue is found by AI.

## Temporary Fix
After knowing why is this issue. We can temporary fix this problem editing the theme. Use rgba() color, instead of HEX color. 

For example:
- `t.prefs_.set('cursor-color', "#f2cdcd");` → `term_set('cursor-color', 'rgba(63, 222, 233, 0.5)');`

## Test result
I don’t have a Mac; it was only tested on LiveContainer. The left-hand side works with this patch. The right-hand side works without this patch.
Tested with a physical keyboard and a soft keyboard.

https://github.com/user-attachments/assets/f1bd6a18-ca23-4573-ae53-c09f12fd4671

