### PR TITLE
Support DEC mode 2026, synchronized output

### DIFF
--- a/Resources/hterm_all.patches.js
+++ b/Resources/hterm_all.patches.js
@@ -59,10 +59,133 @@ hterm.Terminal.prototype.setCursorVisible = function(state) {
 // DEC mode 1003 and DEC mode 1002 (which hterm does support) are almost identical. The only difference is that mode 1003 includes mouse movement tracking events which are rarely used.
 // This patches hterm to treat DEC mode 1003 the same as DEC mode 1002.
 
+// DEC private mode 2026, synchronized output. Applications that repaint a full
+// screen frequently (Claude Code, neovim, tmux) wrap each frame in
+// CSI ? 2026 h ... CSI ? 2026 l so the terminal can present it atomically.
+// Without it the screen is painted mid-frame and tears, which is very visible
+// while a TUI streams. See blinksh/blink#1977.
+//
+// While a frame is open we swallow render requests and remember that something
+// changed, then paint exactly once on close. A watchdog closes the frame if the
+// end marker never arrives, so a misbehaving app cannot freeze the display.
+var _blinkSyncOutput = {
+  active: false,
+  dirtyRows: false,
+  needsRedraw: false,
+  needsCursor: false,
+  terminal: null,
+  timer: null,
+  WATCHDOG_MS: 150,
+
+  begin: function(terminal) {
+    this.terminal = terminal;
+    _blinkWrapRenderRef(terminal && terminal.scrollPort_);
+    this.active = true;
+
+    var self = this;
+    clearTimeout(this.timer);
+    this.timer = setTimeout(function() { self.end(); }, this.WATCHDOG_MS);
+  },
+
+  end: function() {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    clearTimeout(this.timer);
+    this.timer = null;
+
+    var terminal = this.terminal;
+    var scrollPort = terminal && terminal.scrollPort_;
+    if (!scrollPort) {
+      return;
+    }
+
+    if (this.needsRedraw) {
+      this.needsRedraw = false;
+      hterm.ScrollPort.prototype.scheduleRedraw_original.call(scrollPort);
+    }
+    if (this.dirtyRows) {
+      this.dirtyRows = false;
+      var renderRef = scrollPort.renderRef;
+      // A full touch re-renders every row, which subsumes the individual row
+      // touches we swallowed while the frame was open.
+      if (renderRef && renderRef._blinkTouchOriginal) {
+        renderRef._blinkTouchOriginal();
+      }
+    }
+    if (this.needsCursor) {
+      this.needsCursor = false;
+      hterm.Terminal.prototype.scheduleSyncCursorPosition__original.call(terminal);
+    }
+  },
+};
+
+// The React renderer is instantiated per ScrollPort, so it has to be wrapped on
+// the instance rather than a prototype. Idempotent.
+function _blinkWrapRenderRef(scrollPort) {
+  var renderRef = scrollPort && scrollPort.renderRef;
+  if (!renderRef || renderRef._blinkTouchOriginal) {
+    return;
+  }
+
+  var touch = renderRef.touch.bind(renderRef);
+  var touchRow = renderRef.touchRow.bind(renderRef);
+  renderRef._blinkTouchOriginal = touch;
+
+  // setRows() calls this.touch(), so assigning _rows still happens and only the
+  // paint is deferred.
+  renderRef.touch = function() {
+    if (_blinkSyncOutput.active) {
+      _blinkSyncOutput.dirtyRows = true;
+      return;
+    }
+    touch();
+  };
+
+  renderRef.touchRow = function(row) {
+    if (_blinkSyncOutput.active) {
+      _blinkSyncOutput.dirtyRows = true;
+      return;
+    }
+    touchRow(row);
+  };
+}
+
+hterm.ScrollPort.prototype.scheduleRedraw_original =
+  hterm.ScrollPort.prototype.scheduleRedraw;
+hterm.ScrollPort.prototype.scheduleRedraw = function() {
+  if (_blinkSyncOutput.active) {
+    _blinkSyncOutput.needsRedraw = true;
+    return;
+  }
+  hterm.ScrollPort.prototype.scheduleRedraw_original.call(this);
+};
+
+hterm.Terminal.prototype.scheduleSyncCursorPosition__original =
+  hterm.Terminal.prototype.scheduleSyncCursorPosition_;
+hterm.Terminal.prototype.scheduleSyncCursorPosition_ = function() {
+  if (_blinkSyncOutput.active) {
+    _blinkSyncOutput.needsCursor = true;
+    return;
+  }
+  hterm.Terminal.prototype.scheduleSyncCursorPosition__original.call(this);
+};
+
 hterm.VT.prototype.setDECMode_original = hterm.VT.prototype.setDECMode;
 hterm.VT.prototype.setDECMode = function(code, state) {
   if (code === "1003") {
     code = "1002";
   }
+
+  if (String(code) === "2026") {
+    if (state) {
+      _blinkSyncOutput.begin(this.terminal);
+    } else {
+      _blinkSyncOutput.end();
+    }
+    return;
+  }
+
   hterm.VT.prototype.setDECMode_original.call(this, code, state);
 };

--- a/Resources/term.css
+++ b/Resources/term.css
@@ -1,3 +1,17 @@
+/* The row renderer alternates each row's inline transform between scale(1) and
+   scale(1.0001) on every re-render to force a repaint. The identity value
+   leaves the row uncomposited while the scaled value promotes it to its own
+   layer, and WebKit rasterises glyphs differently in each, so text and rules
+   shimmer by about a pixel as rows redraw. Pin the scaled value so every row
+   stays composited and rasterisation never switches path.
+
+   This has to be CSS because the renderer ships prebuilt in
+   hterm_all.min.js. Rows still repaint: React re-renders their contents
+   regardless of whether the transform value changed. */
+x-screen x-row {
+  transform: scale(1.0001) !important;
+}
+
 /* DejaVu Sans Mono */
 
 @font-face {


### PR DESCRIPTION
Fixes #1977

Applications that repaint often wrap each frame in `CSI ? 2026 h` ... `CSI ? 2026 l` so the terminal can present it atomically. hterm ignores the mode, so Blink paints mid frame and the screen tears while a TUI streams.

Render requests are now held while a frame is open and painted once on close. Row touches from the renderer are held too, since they bypass `scheduleRedraw`. A 150ms watchdog closes an abandoned frame so a misbehaving application cannot wedge the display.

The second commit is related but separable. The row renderer alternates each row's inline transform between `scale(1)` and `scale(1.0001)` on every re-render to force a repaint. Identity leaves the row uncomposited while the scaled value promotes it to its own layer, and WebKit rasterises glyphs differently in each, so text and horizontal rules shift by about a pixel every time a row redraws. Pinning the scaled value keeps rasterisation on one path. This is done in CSS because the renderer ships prebuilt in `hterm_all.min.js`; happy to move it if you would rather change it at source.

Measured on the iOS 27 simulator, 12 row writes inside one frame: 12 paints before, 1 after.

Tested on an iPad Pro M4 over ssh with tmux and a streaming TUI. Note that tmux only forwards 2026 to a client whose terminfo advertises `Sync`.